### PR TITLE
chore: Add goimports to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,13 @@ repos:
         types: [go]
         pass_filenames: false
 
+      - id: go-imports
+        name: goimports
+        entry: bash -c 'goimports -l -w .'
+        language: system
+        types: [go]
+        pass_filenames: false
+
       - id: go-vet
         name: go vet
         entry: bash -c 'go vet ./...'


### PR DESCRIPTION
## Summary
- Added goimports as a pre-commit hook to automatically format and organize Go imports

## Test plan
- [x] Pre-commit hooks run successfully
- [x] goimports hook is executed alongside other Go hooks

🤖 Generated with [Claude Code](https://claude.ai/code)