### PR TITLE
feat: Add Ollama provider support for local LLM integration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	OpenAIAPIKey    string
 	GoogleAPIKey    string
 	AzureAPIKey     string
+	OllamaBaseURL   string
 	Model           string
 	LogLevel        string
 }
@@ -40,6 +41,7 @@ func Load(configFile string) (*Config, error) {
 		OpenAIAPIKey:    os.Getenv("OPENAI_API_KEY"),
 		GoogleAPIKey:    os.Getenv("GOOGLE_API_KEY"),
 		AzureAPIKey:     os.Getenv("AZURE_OPENAI_API_KEY"),
+		OllamaBaseURL:   getEnv("OLLAMA_BASE_URL", "http://localhost:11434"),
 		Model:           getEnv("MODEL", ""),
 		LogLevel:        getEnv("RIGEL_LOG_LEVEL", "info"),
 	}
@@ -48,6 +50,8 @@ func Load(configFile string) (*Config, error) {
 		cfg.Model = "claude-3-5-sonnet-20241022"
 	} else if cfg.Provider == "openai" && cfg.Model == "" {
 		cfg.Model = "gpt-4-turbo-preview"
+	} else if cfg.Provider == "ollama" && cfg.Model == "" {
+		cfg.Model = "llama3.2"
 	}
 
 	return cfg, nil
@@ -78,6 +82,8 @@ func (c *Config) Validate() error {
 		if c.AzureAPIKey == "" {
 			return fmt.Errorf("AZURE_OPENAI_API_KEY is required for Azure provider")
 		}
+	case "ollama":
+		// Ollama doesn't require API key, just base URL which has a default
 	default:
 		return fmt.Errorf("unsupported provider: %s", c.Provider)
 	}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -36,6 +36,8 @@ func NewProvider(cfg *config.Config) (Provider, error) {
 		return NewAnthropicProvider(cfg.AnthropicAPIKey, cfg.Model)
 	case "openai":
 		return nil, fmt.Errorf("OpenAI provider not yet implemented")
+	case "ollama":
+		return NewOllamaProvider(cfg.OllamaBaseURL, cfg.Model)
 	default:
 		if cfg.AnthropicAPIKey != "" {
 			return NewAnthropicProvider(cfg.AnthropicAPIKey, cfg.Model)


### PR DESCRIPTION
## Summary
- Implement Ollama provider to enable local LLM usage with Rigel
- Add HTTP API client for communication with Ollama server
- Support both synchronous and streaming generation modes

## Changes
- Created `internal/llm/ollama.go` with complete Ollama provider implementation
- Updated provider factory to include Ollama option
- Added Ollama configuration (base URL and model selection)
- Default model set to `llama3.2` when using Ollama provider

## Usage
```bash
# Set environment variables
export PROVIDER=ollama
export OLLAMA_BASE_URL=http://localhost:11434  # Optional, this is the default
export MODEL=llama3.2  # Optional, this is the default

# Make sure Ollama is running
ollama run llama3.2

# Run Rigel with local LLM
./rigel
```

## Benefits
- Cost-effective alternative to cloud-based LLM providers
- Data privacy - all processing happens locally
- No API key required
- Full control over model selection and deployment

## Test Plan
- [x] Build project successfully
- [x] Test basic text generation with Ollama
- [x] Test streaming generation functionality
- [x] Verify configuration loading and defaults

🤖 Generated with [Claude Code](https://claude.ai/code)