### PR TITLE
Fix Japanese input handling in chat interface

### DIFF
--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -258,27 +258,15 @@ func (m ChatModel) View() string {
 	if !m.thinking {
 		s.WriteString(promptSymbol)
 		s.WriteString(" ")
-		// Get the value and cursor position from textarea without its styling
-		value := m.input.Value()
-		if value == "" {
-			// Add cursor first when empty
-			if m.input.Focused() {
-				s.WriteString("█")
+		// Use textarea's native rendering to handle IME and cursor properly
+		textareaView := m.input.View()
+		// Handle multi-line alignment by replacing newlines with proper indentation
+		lines := strings.Split(textareaView, "\n")
+		for i, line := range lines {
+			if i > 0 {
+				s.WriteString("\n  ") // 2 spaces to align with prompt symbol + space
 			}
-			s.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("60")).Render(" " + m.input.Placeholder))
-		} else {
-			// Add indentation for multi-line input
-			lines := strings.Split(value, "\n")
-			for i, line := range lines {
-				if i > 0 {
-					s.WriteString("\n  ") // 2 spaces to align with prompt symbol + space
-				}
-				s.WriteString(line)
-			}
-			// Add cursor after text
-			if m.input.Focused() {
-				s.WriteString("█")
-			}
+			s.WriteString(line)
 		}
 
 		// Display command suggestions


### PR DESCRIPTION
## Summary
- Fixed issue where Japanese characters appeared before the prompt symbol during input
- Replaced custom text and cursor rendering with textarea's native rendering
- Improved IME (Input Method Editor) handling for Japanese input

## Test plan
- [x] Build the project successfully
- [ ] Test Japanese input in chat interface
- [ ] Verify prompt symbol positioning is correct
- [ ] Test multi-line input alignment

🤖 Generated with [Claude Code](https://claude.ai/code)