### PR TITLE
feat: Add /model command for interactive model selection

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -225,3 +225,18 @@ func (m *MockLLMProvider) Stream(ctx context.Context, prompt string) (<-chan llm
 	}()
 	return ch, nil
 }
+
+func (m *MockLLMProvider) ListModels(ctx context.Context) ([]llm.Model, error) {
+	return []llm.Model{
+		{Name: "test-model-1"},
+		{Name: "test-model-2"},
+	}, nil
+}
+
+func (m *MockLLMProvider) GetCurrentModel() string {
+	return "test-model-1"
+}
+
+func (m *MockLLMProvider) SetModel(model string) {
+	// Mock implementation - no-op
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -34,6 +34,23 @@ func (m *MockProvider) Stream(ctx context.Context, prompt string) (<-chan llm.St
 	return nil, args.Error(1)
 }
 
+func (m *MockProvider) ListModels(ctx context.Context) ([]llm.Model, error) {
+	args := m.Called(ctx)
+	if models := args.Get(0); models != nil {
+		return models.([]llm.Model), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockProvider) GetCurrentModel() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockProvider) SetModel(model string) {
+	m.Called(model)
+}
+
 type MockTool struct {
 	mock.Mock
 }

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -121,3 +121,21 @@ func (p *AnthropicProvider) Stream(ctx context.Context, prompt string) (<-chan S
 
 	return ch, nil
 }
+
+func (p *AnthropicProvider) ListModels(ctx context.Context) ([]Model, error) {
+	return []Model{
+		{Name: "claude-3-5-sonnet-20241022", Details: ModelDetails{Family: "claude-3-5"}},
+		{Name: "claude-3-5-haiku-20241022", Details: ModelDetails{Family: "claude-3-5"}},
+		{Name: "claude-3-opus-20240229", Details: ModelDetails{Family: "claude-3"}},
+		{Name: "claude-3-sonnet-20240229", Details: ModelDetails{Family: "claude-3"}},
+		{Name: "claude-3-haiku-20240307", Details: ModelDetails{Family: "claude-3"}},
+	}, nil
+}
+
+func (p *AnthropicProvider) GetCurrentModel() string {
+	return p.model
+}
+
+func (p *AnthropicProvider) SetModel(model string) {
+	p.model = model
+}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -11,6 +11,9 @@ type Provider interface {
 	Generate(ctx context.Context, prompt string) (string, error)
 	GenerateWithOptions(ctx context.Context, prompt string, opts GenerateOptions) (string, error)
 	Stream(ctx context.Context, prompt string) (<-chan StreamResponse, error)
+	ListModels(ctx context.Context) ([]Model, error)
+	GetCurrentModel() string
+	SetModel(model string)
 }
 
 type GenerateOptions struct {
@@ -24,6 +27,22 @@ type StreamResponse struct {
 	Content string
 	Error   error
 	Done    bool
+}
+
+type Model struct {
+	Name       string       `json:"name"`
+	Size       int64        `json:"size"`
+	Digest     string       `json:"digest"`
+	ModifiedAt string       `json:"modified_at,omitempty"`
+	Details    ModelDetails `json:"details,omitempty"`
+}
+
+type ModelDetails struct {
+	Format            string   `json:"format"`
+	Family            string   `json:"family"`
+	Families          []string `json:"families"`
+	ParameterSize     string   `json:"parameter_size"`
+	QuantizationLevel string   `json:"quantization_level"`
 }
 
 func NewProvider(cfg *config.Config) (Provider, error) {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -4,10 +4,12 @@ import "github.com/charmbracelet/lipgloss"
 
 // Rigel-inspired color scheme (blue-white star)
 var (
-	promptSymbol    = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true).Render("✦") // Light blue star symbol
-	inputStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("195"))                       // Very light blue-white
-	outputStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	thinkingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Italic(true) // Soft blue
-	suggestionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))              // Gray for suggestions
-	highlightStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)    // Highlighted suggestion
+	promptSymbol       = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true).Render("✦") // Light blue star symbol
+	inputStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("195"))                       // Very light blue-white
+	outputStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	thinkingStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Italic(true) // Soft blue
+	suggestionStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))              // Gray for suggestions
+	highlightStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)    // Highlighted suggestion
+	currentModelStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)    // Current model in blue
+	selectedModelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("226"))              // Selected model in yellow
 )


### PR DESCRIPTION
## Summary
- Implemented `/model` command for interactive model selection
- Added support for listing and switching between available AI models
- Created intuitive model selector UI with filtering capabilities

## Features
- **Provider Interface Extensions**: Added `ListModels()`, `GetCurrentModel()`, `SetModel()` methods
- **Ollama Integration**: Fetches installed models via `/api/tags` endpoint
- **Anthropic Support**: Provides static list of available Claude models
- **Interactive Selection**: 
  - Real-time incremental search/filtering
  - Arrow key navigation (up/down)
  - Visual indicators for current model (blue) and cursor position (yellow)
  - Immediate model switching without restarting conversation

## Test plan
- [x] Build and run the application
- [x] Test `/model` command functionality
- [x] Verify model listing for both Ollama and Anthropic providers
- [x] Test filtering with partial model names
- [x] Confirm immediate model switching works
- [x] All tests pass with mock implementations

🤖 Generated with [Claude Code](https://claude.ai/code)