### PR TITLE
feat: Auto-include AGENTS.md content in LLM context

### DIFF
--- a/examples/test_agents_context.go
+++ b/examples/test_agents_context.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/mizzy/rigel/internal/llm"
+)
+
+// This example demonstrates how AGENTS.md content is automatically included
+// in the LLM context when making requests.
+func main() {
+	// Check if AGENTS.md exists
+	if _, err := os.Stat("AGENTS.md"); os.IsNotExist(err) {
+		fmt.Println("AGENTS.md not found in current directory")
+		fmt.Println("The LLM will proceed without repository context")
+	} else {
+		fmt.Println("AGENTS.md found - it will be included in the LLM context")
+	}
+
+	// Initialize provider (example with Anthropic)
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		log.Fatal("ANTHROPIC_API_KEY environment variable not set")
+	}
+
+	provider, err := llm.NewAnthropicProvider(apiKey, "claude-3-5-sonnet-20241022")
+	if err != nil {
+		log.Fatalf("Failed to create provider: %v", err)
+	}
+
+	// Make a request - AGENTS.md will be automatically included
+	ctx := context.Background()
+	response, err := provider.GenerateWithOptions(ctx,
+		"What is the main purpose of this repository based on the context?",
+		llm.GenerateOptions{
+			SystemPrompt: "You are a helpful coding assistant.",
+			Temperature:  0.7,
+		})
+
+	if err != nil {
+		log.Fatalf("Failed to generate response: %v", err)
+	}
+
+	fmt.Println("\nLLM Response:")
+	fmt.Println(response)
+}

--- a/internal/llm/agents_loader.go
+++ b/internal/llm/agents_loader.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// LoadAgentsMD loads the AGENTS.md file content from the current working directory
+func LoadAgentsMD() (string, error) {
+	// Get current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Look for AGENTS.md in the current directory
+	agentsPath := filepath.Join(cwd, "AGENTS.md")
+
+	// Check if file exists
+	if _, err := os.Stat(agentsPath); os.IsNotExist(err) {
+		// Return empty string if file doesn't exist (not an error)
+		return "", nil
+	}
+
+	// Read the file
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read AGENTS.md: %w", err)
+	}
+
+	return string(content), nil
+}
+
+// PrependAgentsContext prepends AGENTS.md content to the system prompt if available
+func PrependAgentsContext(systemPrompt string) string {
+	agentsContent, err := LoadAgentsMD()
+	if err != nil {
+		// Log error but continue without AGENTS.md content
+		// We don't want to fail the entire request
+		return systemPrompt
+	}
+
+	if agentsContent == "" {
+		// No AGENTS.md file found
+		return systemPrompt
+	}
+
+	// Prepend AGENTS.md content with a separator
+	contextPrompt := fmt.Sprintf(`# Repository Context from AGENTS.md
+
+%s
+
+---
+
+# System Instructions
+
+%s`, agentsContent, systemPrompt)
+
+	return contextPrompt
+}

--- a/internal/llm/agents_loader_test.go
+++ b/internal/llm/agents_loader_test.go
@@ -1,0 +1,133 @@
+package llm
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAgentsMD(t *testing.T) {
+	t.Run("loads AGENTS.md when it exists", func(t *testing.T) {
+		// Create a temporary directory
+		tmpDir, err := os.MkdirTemp("", "test-agents")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to the temporary directory
+		originalDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+		defer os.Chdir(originalDir)
+
+		// Create a test AGENTS.md file
+		testContent := "# Test AGENTS.md\nThis is test content."
+		err = os.WriteFile("AGENTS.md", []byte(testContent), 0644)
+		require.NoError(t, err)
+
+		// Load the file
+		content, err := LoadAgentsMD()
+		assert.NoError(t, err)
+		assert.Equal(t, testContent, content)
+	})
+
+	t.Run("returns empty string when AGENTS.md doesn't exist", func(t *testing.T) {
+		// Create a temporary directory without AGENTS.md
+		tmpDir, err := os.MkdirTemp("", "test-no-agents")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to the temporary directory
+		originalDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+		defer os.Chdir(originalDir)
+
+		// Load the file (should not exist)
+		content, err := LoadAgentsMD()
+		assert.NoError(t, err)
+		assert.Empty(t, content)
+	})
+}
+
+func TestPrependAgentsContext(t *testing.T) {
+	t.Run("prepends AGENTS.md content when available", func(t *testing.T) {
+		// Create a temporary directory
+		tmpDir, err := os.MkdirTemp("", "test-prepend")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to the temporary directory
+		originalDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+		defer os.Chdir(originalDir)
+
+		// Create a test AGENTS.md file
+		agentsContent := "# Repository Overview\nTest repository content."
+		err = os.WriteFile("AGENTS.md", []byte(agentsContent), 0644)
+		require.NoError(t, err)
+
+		// Test with existing system prompt
+		systemPrompt := "You are a helpful assistant."
+		result := PrependAgentsContext(systemPrompt)
+
+		assert.Contains(t, result, "Repository Context from AGENTS.md")
+		assert.Contains(t, result, agentsContent)
+		assert.Contains(t, result, "System Instructions")
+		assert.Contains(t, result, systemPrompt)
+	})
+
+	t.Run("returns original prompt when AGENTS.md doesn't exist", func(t *testing.T) {
+		// Create a temporary directory without AGENTS.md
+		tmpDir, err := os.MkdirTemp("", "test-no-prepend")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to the temporary directory
+		originalDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+		defer os.Chdir(originalDir)
+
+		// Test with system prompt
+		systemPrompt := "You are a helpful assistant."
+		result := PrependAgentsContext(systemPrompt)
+
+		// Should return the original prompt unchanged
+		assert.Equal(t, systemPrompt, result)
+	})
+
+	t.Run("handles empty system prompt with AGENTS.md", func(t *testing.T) {
+		// Create a temporary directory
+		tmpDir, err := os.MkdirTemp("", "test-empty-prompt")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
+
+		// Change to the temporary directory
+		originalDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(tmpDir)
+		require.NoError(t, err)
+		defer os.Chdir(originalDir)
+
+		// Create a test AGENTS.md file
+		agentsContent := "# Repository Overview\nTest repository content."
+		err = os.WriteFile("AGENTS.md", []byte(agentsContent), 0644)
+		require.NoError(t, err)
+
+		// Test with empty system prompt
+		result := PrependAgentsContext("")
+
+		assert.Contains(t, result, "Repository Context from AGENTS.md")
+		assert.Contains(t, result, agentsContent)
+		// The system instructions section should be empty
+		assert.True(t, strings.HasSuffix(strings.TrimSpace(result), "# System Instructions"))
+	})
+}

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -57,9 +57,19 @@ func (p *AnthropicProvider) GenerateWithOptions(ctx context.Context, prompt stri
 		MaxTokens: anthropic.F(int64(maxTokens)),
 	}
 
-	if opts.SystemPrompt != "" {
+	// Include AGENTS.md content in the system prompt
+	systemPrompt := opts.SystemPrompt
+	if systemPrompt == "" {
+		// Load AGENTS.md even if no system prompt is provided
+		systemPrompt = PrependAgentsContext("")
+	} else {
+		// Prepend AGENTS.md to existing system prompt
+		systemPrompt = PrependAgentsContext(systemPrompt)
+	}
+
+	if systemPrompt != "" {
 		params.System = anthropic.F([]anthropic.TextBlockParam{
-			anthropic.NewTextBlock(opts.SystemPrompt),
+			anthropic.NewTextBlock(systemPrompt),
 		})
 	}
 

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -74,8 +74,18 @@ func (p *OllamaProvider) GenerateWithOptions(ctx context.Context, prompt string,
 		Stream: false,
 	}
 
-	if opts.SystemPrompt != "" {
-		reqBody.System = opts.SystemPrompt
+	// Include AGENTS.md content in the system prompt
+	systemPrompt := opts.SystemPrompt
+	if systemPrompt == "" {
+		// Load AGENTS.md even if no system prompt is provided
+		systemPrompt = PrependAgentsContext("")
+	} else {
+		// Prepend AGENTS.md to existing system prompt
+		systemPrompt = PrependAgentsContext(systemPrompt)
+	}
+
+	if systemPrompt != "" {
+		reqBody.System = systemPrompt
 	}
 
 	if opts.Temperature > 0 {


### PR DESCRIPTION
## Summary
- Automatically includes AGENTS.md file content in LLM context for all requests
- Provides repository context to improve LLM understanding of the codebase
- Gracefully handles missing AGENTS.md files

## Changes
- Added `agents_loader.go` with utilities to load and prepend AGENTS.md content
- Updated `AnthropicProvider` to include AGENTS.md in system prompts
- Updated `OllamaProvider` to include AGENTS.md in system prompts
- Added comprehensive tests for the new functionality
- Added example demonstrating the feature usage

## Test plan
- [x] Run unit tests: `go test ./internal/llm/...`
- [x] Build the project: `go build ./cmd/rigel`
- [x] Test with AGENTS.md present in working directory
- [x] Test without AGENTS.md to ensure graceful fallback
- [ ] Manual testing with actual LLM providers

🤖 Generated with [Claude Code](https://claude.ai/code)