### PR TITLE
feat: Add provider selector command and enhance model management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Common Development Commands
+
+### Build and Run
+```bash
+# Build the binary
+make build                    # Output to ./bin/rigel
+go build -o rigel cmd/rigel/main.go  # Direct build
+
+# Run in development mode
+make run                      # Run without building
+go run cmd/rigel/main.go      # Direct run
+make dev                      # Build and run
+
+# Install globally
+make install                  # Install to $GOPATH/bin
+go install ./cmd/rigel
+```
+
+### Testing
+```bash
+# Run all tests
+make test                     # Verbose test output
+go test ./...                 # Standard test run
+
+# Run tests for specific package
+go test ./internal/llm -v    # Test LLM package
+go test ./internal/tui -v    # Test TUI package
+
+# Test with coverage
+make test-coverage            # Coverage report
+go test -cover ./...          # Direct coverage
+
+# Run single test
+go test -run TestAnthropicProvider ./internal/llm
+
+# Integration tests (requires API keys)
+ANTHROPIC_API_KEY=xxx go test ./internal/llm -run TestAnthropicProvider_Generate
+```
+
+### Linting and Formatting
+```bash
+# Run linter (if golangci-lint installed)
+make lint
+golangci-lint run
+
+# Format code
+go fmt ./...
+
+# Static analysis
+staticcheck ./...
+
+# Pre-commit hooks (if configured)
+pre-commit run --all-files
+```
+
+## High-Level Architecture
+
+### Core Components
+
+**TUI Chat System** (`internal/tui/`)
+- `chat.go`: Main chat model managing state, input handling, and rendering
+- `commands.go`: Slash command handlers (`/init`, `/model`, `/provider`, `/help`)
+- Provider and model selection are handled through interactive modal interfaces
+- Uses Bubbletea framework for terminal UI with inline mode (no alternate screen)
+
+**LLM Provider System** (`internal/llm/`)
+- `provider.go`: Common interface for all LLM providers
+- `anthropic.go`: Anthropic implementation with API model listing and fallback
+- `ollama.go`: Ollama local model support
+- Provider switching happens dynamically through config updates and provider recreation
+
+**Command Flow**
+1. User types `/provider` or `/model` command
+2. Command handler fetches available options (from API or config)
+3. Interactive selector UI is shown (arrow keys to navigate, Enter to select)
+4. On selection, provider/model is switched and config updated
+5. Chat continues with new provider/model
+
+### Key Design Patterns
+
+**Provider Selection**:
+- Runtime provider switching without restart
+- Config object passed to ChatModel for dynamic updates
+- Provider interface allows transparent switching between Anthropic/Ollama
+
+**Model Discovery**:
+- Anthropic: Attempts API call to `/v1/models`, falls back to hardcoded list
+- Ollama: Uses local API to list installed models
+- Default models: Claude Sonnet 4 for Anthropic, gpt-oss:20b for Ollama
+
+**State Management**:
+- ChatModel maintains provider, config, and UI state
+- Selection modes (provider/model) are exclusive states
+- ESC key properly exits selection modes and resets thinking state
+
+### Configuration
+
+**Environment Variables** (`.env` file or shell):
+```
+PROVIDER=anthropic|ollama
+ANTHROPIC_API_KEY=xxx
+MODEL=claude-sonnet-4-20250514  # Optional, uses provider defaults
+OLLAMA_BASE_URL=http://localhost:11434
+```
+
+**Provider Defaults**:
+- Anthropic: `claude-sonnet-4-20250514`
+- Ollama: `gpt-oss:20b`
+- OpenAI (planned): `gpt-4-turbo-preview`
+
+### Repository Analysis
+
+The `/init` command generates `AGENTS.md` by:
+1. Analyzing repository structure and code patterns
+2. Using LLM to generate comprehensive documentation
+3. Prepending AGENTS.md content to system prompts automatically
+
+This context helps the AI understand the codebase structure when answering questions.
+
+## Important Implementation Details
+
+- **Terminal Colors**: Uses Rigel theme (blue #5793ff for highlights)
+- **Input Handling**: Alt+Enter for multiline, Tab for command completion
+- **Error Recovery**: API failures fall back to hardcoded model lists
+- **Testing**: Most tests mock LLM responses with httptest
+- **Security**: No API keys in code, loaded from environment only

--- a/cmd/rigel/main.go
+++ b/cmd/rigel/main.go
@@ -75,7 +75,7 @@ review, and improve code through natural language interactions.`,
 }
 
 func runChatMode(provider llm.Provider) {
-	model := tui.NewChatModel(provider)
+	model := tui.NewChatModel(provider, cfg)
 	p := tea.NewProgram(model)
 
 	if _, err := p.Run(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,7 @@ func Load(configFile string) (*Config, error) {
 	}
 
 	if cfg.Provider == "anthropic" && cfg.Model == "" {
-		cfg.Model = "claude-3-5-sonnet-20241022"
+		cfg.Model = "claude-sonnet-4-20250514"
 	} else if cfg.Provider == "openai" && cfg.Model == "" {
 		cfg.Model = "gpt-4-turbo-preview"
 	} else if cfg.Provider == "ollama" && cfg.Model == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,7 +81,7 @@ func TestLoad(t *testing.T) {
 			expectedConfig: &Config{
 				Provider:        "anthropic",
 				AnthropicAPIKey: "test-anthropic-key",
-				Model:           "claude-3-5-sonnet-20241022",
+				Model:           "claude-sonnet-4-20250514",
 				LogLevel:        "info",
 			},
 		},
@@ -122,7 +122,7 @@ func TestLoad(t *testing.T) {
 			expectedConfig: &Config{
 				Provider:        "anthropic",
 				AnthropicAPIKey: "test-key",
-				Model:           "claude-3-5-sonnet-20241022",
+				Model:           "claude-sonnet-4-20250514",
 				LogLevel:        "debug",
 			},
 		},

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -27,7 +27,7 @@ func TestNewAnthropicProvider(t *testing.T) {
 			name:          "valid with default model",
 			apiKey:        "test-api-key",
 			model:         "",
-			expectedModel: "claude-3-5-sonnet-20241022",
+			expectedModel: "claude-sonnet-4-20250514",
 			expectedError: false,
 		},
 		{

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -18,6 +18,7 @@ var availableCommands = []struct {
 }{
 	{"/init", "Analyze repository and generate AGENTS.md"},
 	{"/model", "Show current model and select from available models"},
+	{"/provider", "Switch between LLM providers (Anthropic, Ollama, etc.)"},
 	{"/help", "Show available commands"},
 	{"/clear", "Clear chat history"},
 	{"/exit", "Exit the application"},
@@ -32,6 +33,9 @@ func (m *ChatModel) handleCommand(trimmedPrompt string) tea.Cmd {
 
 	case "/model":
 		return m.showModelSelector()
+
+	case "/provider":
+		return m.showProviderSelector()
 
 	case "/help":
 		return m.showHelp()
@@ -126,6 +130,30 @@ func (m *ChatModel) showModelSelector() tea.Cmd {
 		return modelSelectorMsg{
 			currentModel: currentModel,
 			models:       models,
+		}
+	}
+}
+
+type providerSelectorMsg struct {
+	currentProvider string
+	providers       []string
+	err             error
+}
+
+func (m *ChatModel) showProviderSelector() tea.Cmd {
+	return func() tea.Msg {
+		// Get available providers
+		providers := []string{"anthropic", "ollama"}
+
+		// Get current provider from config
+		currentProvider := ""
+		if m.config != nil {
+			currentProvider = m.config.Provider
+		}
+
+		return providerSelectorMsg{
+			currentProvider: currentProvider,
+			providers:       providers,
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `/provider` command to switch between LLM providers (Anthropic, Ollama) at runtime
- Implement dynamic model fetching from Anthropic API with automatic fallback to hardcoded list
- Add Claude 4 models to default model list and update default to claude-sonnet-4-20250514

## Key Changes

### New Features
- **Provider Selector**: Interactive UI to switch between Anthropic and Ollama providers without restart
- **Dynamic Model Discovery**: Fetch available models from Anthropic API (`/v1/models` endpoint)
- **Claude 4 Support**: Added Claude Sonnet 4 and Opus 4 models to the default list

### Bug Fixes
- Fixed ESC key handling in model/provider selection modes (was stuck in "Thinking..." state)
- Properly reset UI state when canceling selection

### Documentation
- Created CLAUDE.md with development commands and architecture overview for future Claude instances

## Test Plan
- [x] Test `/provider` command switches between providers
- [x] Test `/model` command with Anthropic provider
- [x] Test ESC key properly exits selection modes
- [x] Test API fallback when model fetch fails
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)