### PR TITLE
feat: Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,15 @@
 BINARY_NAME=rigel
 BINARY_PATH=./bin/$(BINARY_NAME)
 MAIN_PATH=cmd/rigel/main.go
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.1.0")
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+LDFLAGS := -X 'github.com/mizzy/rigel/internal/version.Version=$(VERSION)' \
+           -X 'github.com/mizzy/rigel/internal/version.GitCommit=$(GIT_COMMIT)' \
+           -X 'github.com/mizzy/rigel/internal/version.BuildDate=$(BUILD_DATE)'
 
 build:
-	go build -o $(BINARY_PATH) $(MAIN_PATH)
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_PATH) $(MAIN_PATH)
 
 run:
 	go run $(MAIN_PATH)
@@ -21,7 +27,7 @@ clean:
 	rm -f $(BINARY_PATH)
 
 install:
-	go install ./cmd/rigel
+	go install -ldflags "$(LDFLAGS)" ./cmd/rigel
 
 deps:
 	go mod download

--- a/cmd/rigel/main.go
+++ b/cmd/rigel/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mizzy/rigel/internal/llm"
 	"github.com/mizzy/rigel/internal/sandbox"
 	"github.com/mizzy/rigel/internal/tui"
+	"github.com/mizzy/rigel/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -107,6 +108,7 @@ func runChatMode(provider llm.Provider) {
 }
 
 func init() {
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.Flags().BoolVar(&sandboxFlag, "sandbox", false, "Force enable sandbox mode (default on macOS)")
 	rootCmd.Flags().BoolVar(&noSandboxFlag, "no-sandbox", false, "Disable sandbox mode explicitly")
 }
@@ -115,4 +117,12 @@ func shouldEnableSandboxByDefault() bool {
 	// Enable sandbox by default on macOS
 	// Can be expanded to other platforms in the future
 	return runtime.GOOS == "darwin"
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of rigel",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.String())
+	},
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	Version   = "0.1.0"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)
+
+func String() string {
+	return fmt.Sprintf("rigel version %s (commit: %s, built: %s, %s/%s)",
+		Version,
+		GitCommit,
+		BuildDate,
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+}
+
+func Short() string {
+	return Version
+}


### PR DESCRIPTION
## Summary
- Added `rigel version` command to display version information
- Shows version number, git commit hash, build date, and platform (OS/architecture)
- Version information is injected at build time through ldflags in the Makefile

## Changes
- Created `internal/version` package to manage version information
- Added version subcommand to main.go using cobra
- Updated Makefile to inject version, commit hash, and build date at compile time

## Test plan
- [x] Build with `make build`
- [x] Run `./bin/rigel version` - should display version info
- [x] Verify main functionality still works with piped input
- [x] Pre-commit hooks pass

## Example output
```
$ rigel version
rigel version 0.1.0 (commit: 3b4fdcd, built: 2025-08-30T11:48:15Z, darwin/arm64)
```

🤖 Generated with [Claude Code](https://claude.ai/code)