### PR TITLE
refactor: Extract TUI rendering and handling logic into focused modules

### DIFF
--- a/internal/tui/handlers/keys.go
+++ b/internal/tui/handlers/keys.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// HandleSpecialKeys handles special key combinations like Ctrl+C
+func HandleSpecialKeys(msg tea.KeyMsg, thinking bool, ctrlCPressed *bool, quitting *bool) (tea.Cmd, bool) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		if !*ctrlCPressed {
+			*ctrlCPressed = true
+			return tea.Tick(500*time.Millisecond, func(time.Time) tea.Msg {
+				return "reset_ctrl_c"
+			}), true
+		}
+		*quitting = true
+		return tea.Quit, true
+
+	case tea.KeyEsc:
+		if thinking {
+			return nil, true // Don't allow escape during thinking
+		}
+		return nil, false
+	}
+
+	return nil, false
+}
+
+// HandleNavigationKeys handles up/down arrow keys for navigation
+func HandleNavigationKeys(msg tea.KeyMsg, selectedIndex *int, maxIndex int) bool {
+	switch msg.Type {
+	case tea.KeyUp:
+		if *selectedIndex > 0 {
+			*selectedIndex--
+		}
+		return true
+
+	case tea.KeyDown:
+		if *selectedIndex < maxIndex-1 {
+			*selectedIndex++
+		}
+		return true
+	}
+
+	return false
+}
+
+// HandleFilterInput handles text input for filtering
+func HandleFilterInput(input string, oldFilter string, items []interface{}, filterFunc func([]interface{}, string) []interface{}) ([]interface{}, bool) {
+	if input != oldFilter {
+		filtered := filterFunc(items, input)
+		return filtered, true
+	}
+	return nil, false
+}

--- a/internal/tui/render/chat.go
+++ b/internal/tui/render/chat.go
@@ -1,0 +1,147 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+)
+
+// Exchange represents a single chat exchange
+type Exchange struct {
+	Prompt   string
+	Response string
+}
+
+var (
+	promptSymbol    = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true).Render("✦")
+	inputStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("195"))
+	outputStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	thinkingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Italic(true)
+	suggestionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	highlightStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)
+)
+
+// GetTerminalWidth returns the terminal width or a default value
+func GetTerminalWidth() int {
+	width, _, err := term.GetSize(0)
+	if err != nil || width < 40 {
+		return 80 // Default fallback width
+	}
+	if width > 120 {
+		width = 120 // Max width for better readability
+	}
+	return width
+}
+
+// ChatHistory renders the conversation history
+func ChatHistory(history []Exchange) string {
+	if len(history) == 0 {
+		return ""
+	}
+
+	var s strings.Builder
+
+	// Get terminal width and calculate usable widths
+	termWidth := GetTerminalWidth()
+	promptWidth := termWidth - 3 // Account for prompt symbol and space
+	responseWidth := termWidth - 2
+
+	for _, ex := range history {
+		// User prompt with > symbol
+		s.WriteString(promptSymbol)
+		s.WriteString(" ")
+
+		// Use lipgloss Width() for proper wrapping
+		promptStyle := inputStyle.Width(promptWidth)
+		s.WriteString(promptStyle.Render(ex.Prompt))
+		s.WriteString("\n\n")
+
+		// Assistant response with wrapping
+		responseStyle := outputStyle.Width(responseWidth)
+		s.WriteString(responseStyle.Render(ex.Response))
+		s.WriteString("\n\n")
+	}
+
+	return s.String()
+}
+
+// ThinkingState renders the thinking indicator
+func ThinkingState(currentPrompt string, spinner string) string {
+	if currentPrompt == "" {
+		return ""
+	}
+
+	var s strings.Builder
+	termWidth := GetTerminalWidth()
+	promptWidth := termWidth - 3
+
+	s.WriteString(promptSymbol)
+	s.WriteString(" ")
+
+	promptStyle := inputStyle.Width(promptWidth)
+	s.WriteString(promptStyle.Render(currentPrompt))
+	s.WriteString("\n\n")
+	s.WriteString(spinner)
+	s.WriteString(thinkingStyle.Render(" Thinking..."))
+	s.WriteString("\n")
+
+	return s.String()
+}
+
+// Command represents a command with description
+type Command struct {
+	Command     string
+	Description string
+}
+
+// CommandSuggestions renders command suggestions
+func CommandSuggestions(suggestions []string, selectedIndex int, commands []Command) string {
+	if len(suggestions) == 0 {
+		return ""
+	}
+
+	var s strings.Builder
+	s.WriteString("\n\n")
+	s.WriteString(suggestionStyle.Render("Commands:"))
+	s.WriteString("\n")
+
+	for i, suggestion := range suggestions {
+		if i == selectedIndex {
+			s.WriteString(highlightStyle.Render(fmt.Sprintf("  → %s", suggestion)))
+		} else {
+			s.WriteString(suggestionStyle.Render(fmt.Sprintf("    %s", suggestion)))
+		}
+
+		// Add description
+		for _, cmd := range commands {
+			if cmd.Command == suggestion {
+				s.WriteString(suggestionStyle.Render(fmt.Sprintf(" - %s", cmd.Description)))
+				break
+			}
+		}
+		s.WriteString("\n")
+	}
+
+	s.WriteString("\n")
+	s.WriteString(suggestionStyle.Render("Press Tab or Enter to complete, ↑/↓ to navigate"))
+
+	return s.String()
+}
+
+// ErrorMessage renders error messages
+func ErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return "\n\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(fmt.Sprintf("Error: %v", err))
+}
+
+// InfoMessage renders info messages
+func InfoMessage(message string) string {
+	if message == "" {
+		return ""
+	}
+	return "\n\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render(message)
+}

--- a/internal/tui/render/input.go
+++ b/internal/tui/render/input.go
@@ -1,0 +1,24 @@
+package render
+
+import (
+	"strings"
+)
+
+// InputPrompt renders the input prompt with proper alignment
+func InputPrompt(inputView string) string {
+	var s strings.Builder
+
+	s.WriteString(promptSymbol)
+	s.WriteString(" ")
+
+	// Handle multi-line alignment by replacing newlines with proper indentation
+	lines := strings.Split(inputView, "\n")
+	for i, line := range lines {
+		if i > 0 {
+			s.WriteString("\n  ") // 2 spaces to align with prompt symbol + space
+		}
+		s.WriteString(line)
+	}
+
+	return s.String()
+}

--- a/internal/tui/render/selectors.go
+++ b/internal/tui/render/selectors.go
@@ -1,0 +1,71 @@
+package render
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mizzy/rigel/internal/llm"
+)
+
+// ModelSelector renders the model selection interface
+func ModelSelector(models []llm.Model, selectedIndex int, filter string) string {
+	if len(models) == 0 {
+		return "No models available"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Select a model:\n\n")
+
+	// Show filter if active
+	if filter != "" {
+		sb.WriteString(fmt.Sprintf("Filter: %s\n\n", filter))
+	}
+
+	// Display models
+	for i, model := range models {
+		displayName := model.Name
+		if model.Details.Family != "" {
+			displayName = fmt.Sprintf("%s (%s)", model.Name, model.Details.Family)
+		}
+
+		if i == selectedIndex {
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)
+			sb.WriteString(style.Render(fmt.Sprintf("> %s", displayName)))
+		} else {
+			sb.WriteString(fmt.Sprintf("  %s", displayName))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString("↑/↓: navigate • Enter: select • /: filter • Esc: cancel")
+
+	return sb.String()
+}
+
+// ProviderSelector renders the provider selection interface
+func ProviderSelector(providers []string, selectedIndex int) string {
+	if len(providers) == 0 {
+		return "No providers available"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Select a provider:\n\n")
+
+	// Display providers
+	for i, provider := range providers {
+		if i == selectedIndex {
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)
+			sb.WriteString(style.Render(fmt.Sprintf("> %s", provider)))
+		} else {
+			sb.WriteString(fmt.Sprintf("  %s", provider))
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString("↑/↓: navigate • Enter: select • Esc: cancel")
+
+	return sb.String()
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -3,15 +3,8 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 // Rigel-inspired color scheme (blue-white star)
+// Note: Most styles moved to render package for better organization
 var (
-	promptSymbol       = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true).Render("✦") // Light blue star symbol
-	inputStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("195"))                       // Very light blue-white
-	outputStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	thinkingStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Italic(true) // Soft blue
-	suggestionStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))              // Gray for suggestions
-	highlightStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)    // Highlighted suggestion
-	currentModelStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)    // Current model in blue
-	selectedModelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("226"))              // Selected model in yellow
 
 	// Status command styles
 	statusHeaderStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)   // Blue headers


### PR DESCRIPTION
## Summary
• Split chat.go from 782 lines to 655 lines (16.2% reduction)
• Extract rendering logic to internal/tui/render/ package for better organization
• Extract key handling to internal/tui/handlers/ package  
• Improve code maintainability and reusability

## Changes Made
- **internal/tui/render/chat.go**: Chat history, thinking state, message rendering (146 lines)
- **internal/tui/render/selectors.go**: Model and provider selection UI (70 lines)
- **internal/tui/render/input.go**: Input prompt rendering with alignment (23 lines)
- **internal/tui/handlers/keys.go**: Key event handling utilities (57 lines)
- **internal/tui/chat.go**: Refactored to use extracted render functions (655 lines, down from 782)
- **internal/tui/styles.go**: Cleaned up unused styles moved to render package

## Test plan
- [x] All packages build successfully
- [x] Full project builds without errors
- [x] Pre-existing functionality preserved
- [x] View rendering logic properly separated and reusable

🤖 Generated with [Claude Code](https://claude.ai/code)