### PR TITLE
refactor: Extract LLM request handler from terminal package

### DIFF
--- a/internal/ui/terminal/selection.go
+++ b/internal/ui/terminal/selection.go
@@ -5,6 +5,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mizzy/rigel/internal/llm"
+	"github.com/mizzy/rigel/internal/ui/handlers"
 )
 
 func (m *Model) handleProviderSelectionKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -122,8 +123,8 @@ func (m *Model) switchModel(model llm.Model) tea.Cmd {
 	}
 
 	return func() tea.Msg {
-		return aiResponse{
-			content: fmt.Sprintf("Switched to model: %s", model.Name),
+		return handlers.AIResponse{
+			Content: fmt.Sprintf("Switched to model: %s", model.Name),
 		}
 	}
 }

--- a/internal/ui/terminal/types.go
+++ b/internal/ui/terminal/types.go
@@ -2,12 +2,6 @@ package terminal
 
 import "github.com/mizzy/rigel/internal/llm"
 
-// aiResponse represents a response from the AI
-type aiResponse struct {
-	content string
-	err     error
-}
-
 // providerSwitchResponse represents a provider switch response
 type providerSwitchResponse struct {
 	provider     llm.Provider

--- a/internal/ui/terminal/update.go
+++ b/internal/ui/terminal/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mizzy/rigel/internal/command"
+	"github.com/mizzy/rigel/internal/ui/handlers"
 )
 
 // Update handles incoming messages and returns updated application state
@@ -190,7 +191,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case providerSelectorMsg:
 		if msg.err != nil {
 			return m, func() tea.Msg {
-				return aiResponse{err: msg.err}
+				return handlers.AIResponse{Error: msg.err}
 			}
 		}
 
@@ -200,7 +201,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case modelSelectorMsg:
 		if msg.err != nil {
 			return m, func() tea.Msg {
-				return aiResponse{err: msg.err}
+				return handlers.AIResponse{Error: msg.err}
 			}
 		}
 
@@ -225,7 +226,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.chatState.ClearCurrentPrompt()
 			case "request":
 				// Handle normal prompts (non-commands)
-				return m, m.requestResponse(msg.Prompt)
+				return m, handlers.RequestResponse(msg.Prompt, m.llmState, m.chatState)
 			case "model_selector":
 				if msg.ModelSelector != nil {
 					return m, func() tea.Msg { return *msg.ModelSelector }
@@ -256,7 +257,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case command.ModelSelectorMsg:
 		if msg.Error != nil {
 			return m, func() tea.Msg {
-				return aiResponse{err: msg.Error}
+				return handlers.AIResponse{Error: msg.Error}
 			}
 		}
 
@@ -308,13 +309,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.chatState.ClearCurrentPrompt()
 		return m, nil
 
-	case aiResponse:
+	case handlers.AIResponse:
 		m.chatState.SetThinking(false)
 
-		if msg.err != nil {
-			m.chatState.SetError(msg.err)
+		if msg.Error != nil {
+			m.chatState.SetError(msg.Error)
 		} else {
-			m.chatState.AddExchange(m.chatState.GetCurrentPrompt(), msg.content)
+			m.chatState.AddExchange(m.chatState.GetCurrentPrompt(), msg.Content)
 			m.chatState.ClearCurrentPrompt()
 		}
 		return m, nil


### PR DESCRIPTION
## Summary
Improves separation of concerns by moving LLM interaction logic out of the terminal UI package into a dedicated handler module.

## Changes Made
- **Extracted `requestResponse` function**: Moved from `internal/ui/terminal/handlers.go` to `internal/ui/handlers/llm.go`
- **Renamed to `RequestResponse`**: Better naming for the exported function
- **Created `handlers.AIResponse` type**: Replaces the terminal-specific `aiResponse` type
- **Updated all references**: Terminal package now imports and uses the new handler
- **Cleaned up unused code**: Removed old type definitions and files

## Benefits
- ✅ **Better separation of concerns**: UI logic separate from business logic
- ✅ **Reusable components**: Handler can be used by other UI modules
- ✅ **Improved testability**: LLM logic can be tested independently
- ✅ **Cleaner architecture**: Terminal package focused on UI responsibilities
- ✅ **Type safety**: Consistent AIResponse type across the application

## File Changes
```diff
internal/ui/terminal/handlers.go → internal/ui/handlers/llm.go
internal/ui/terminal/types.go (removed aiResponse type)  
internal/ui/terminal/update.go (updated imports and usage)
internal/ui/terminal/selection.go (updated type usage)
```

This is the first step in a broader refactoring effort to extract functions from the terminal package, keeping only the core Bubble Tea interface methods (`Init()`, `Update()`, `View()`).

🤖 Generated with [Claude Code](https://claude.ai/code)