### PR TITLE
refactor: Remove remaining helper methods from Model

### DIFF
--- a/internal/ui/terminal/model.go
+++ b/internal/ui/terminal/model.go
@@ -10,7 +10,6 @@ import (
 	"github.com/mizzy/rigel/internal/history"
 	"github.com/mizzy/rigel/internal/llm"
 	"github.com/mizzy/rigel/internal/state"
-	"github.com/mizzy/rigel/internal/ui/handlers"
 )
 
 // Model represents the main chat interface
@@ -38,22 +37,6 @@ type Model struct {
 
 // Exchange represents a single chat exchange - using state.Exchange
 type Exchange = state.Exchange
-
-// getHistoryNavigationState returns the current history navigation state
-func (m *Model) getHistoryNavigationState() *handlers.HistoryNavigationState {
-	return &handlers.HistoryNavigationState{
-		InputHistory: m.inputHistory,
-		HistoryIndex: m.historyIndex,
-		CurrentInput: m.currentInput,
-	}
-}
-
-// updateFromHistoryNavigationState updates the model from history navigation state
-func (m *Model) updateFromHistoryNavigationState(state *handlers.HistoryNavigationState) {
-	m.inputHistory = state.InputHistory
-	m.historyIndex = state.HistoryIndex
-	m.currentInput = state.CurrentInput
-}
 
 // NewModel creates a new chat model instance
 func NewModel(provider llm.Provider, cfg *config.Config) *Model {

--- a/internal/ui/terminal/update.go
+++ b/internal/ui/terminal/update.go
@@ -92,9 +92,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.selectedCompletion--
 					}
 				} else {
-					histState := m.getHistoryNavigationState()
+					histState := &handlers.HistoryNavigationState{
+						InputHistory: m.inputHistory,
+						HistoryIndex: m.historyIndex,
+						CurrentInput: m.currentInput,
+					}
 					handlers.NavigateHistory(-1, &m.input, histState)
-					m.updateFromHistoryNavigationState(histState)
+					m.inputHistory = histState.InputHistory
+					m.historyIndex = histState.HistoryIndex
+					m.currentInput = histState.CurrentInput
 				}
 				m.ctrlCPressed = false // Reset Ctrl+C flag
 				m.infoMessage = ""
@@ -105,9 +111,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.selectedCompletion++
 					}
 				} else {
-					histState := m.getHistoryNavigationState()
+					histState := &handlers.HistoryNavigationState{
+						InputHistory: m.inputHistory,
+						HistoryIndex: m.historyIndex,
+						CurrentInput: m.currentInput,
+					}
 					handlers.NavigateHistory(1, &m.input, histState)
-					m.updateFromHistoryNavigationState(histState)
+					m.inputHistory = histState.InputHistory
+					m.historyIndex = histState.HistoryIndex
+					m.currentInput = histState.CurrentInput
 				}
 				m.ctrlCPressed = false // Reset Ctrl+C flag
 				m.infoMessage = ""


### PR DESCRIPTION
## Summary
Complete the terminal package cleanup by removing the last helper methods from Model. Now Model only contains the essential Bubble Tea interface methods plus constructor.

## Changes
- **Removed methods**: `getHistoryNavigationState()`, `updateFromHistoryNavigationState()`
- **Inlined logic**: History navigation state creation/update directly in `Update()`
- **Cleaned imports**: Remove unnecessary handlers import from model.go

## Final Model Methods
Model now contains **only** the essential methods:
- ✅ `NewModel()` - Constructor
- ✅ `Init()` - Bubble Tea interface  
- ✅ `Update()` - Bubble Tea interface
- ✅ `View()` - Bubble Tea interface

## Before/After
**Before**: Model had helper methods for history navigation state management
**After**: History state is managed directly inline, no helper methods remain

This achieves **complete separation** - terminal package is now purely UI-focused with zero business logic or helper methods.

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] No Model methods remain except the 4 essential ones
- [x] History navigation still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)