### PR TITLE
Fix thinking state display and spinner color

### DIFF
--- a/cmd/rigel/main.go
+++ b/cmd/rigel/main.go
@@ -100,7 +100,7 @@ review, and improve code through natural language interactions.`,
 
 func runChatMode(provider llm.Provider) {
 	model := terminal.NewModel(provider, cfg)
-	p := tea.NewProgram(model)
+	p := tea.NewProgram(model, tea.WithInput(os.Stdin), tea.WithOutput(os.Stdout))
 
 	if _, err := p.Run(); err != nil {
 		log.Fatalf("Error running chat: %v", err)

--- a/internal/ui/render/chat.go
+++ b/internal/ui/render/chat.go
@@ -16,6 +16,7 @@ type Exchange struct {
 
 var (
 	promptSymbol    = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true).Render("✦")
+	promptStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true)
 	inputStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("195"))
 	outputStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
 	thinkingStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Italic(true)
@@ -80,11 +81,40 @@ func ThinkingState(currentPrompt string, spinner string) string {
 	s.WriteString(promptSymbol)
 	s.WriteString(" ")
 
-	promptStyle := inputStyle.Width(promptWidth)
-	s.WriteString(promptStyle.Render(currentPrompt))
+	promptLineStyle := inputStyle.Width(promptWidth)
+	s.WriteString(promptLineStyle.Render(currentPrompt))
 	s.WriteString("\n\n")
-	s.WriteString(spinner)
+	s.WriteString(promptStyle.Render(spinner))
 	s.WriteString(thinkingStyle.Render(" Thinking..."))
+	s.WriteString("\n")
+
+	return s.String()
+}
+
+// ThinkingStateWithInput renders the thinking indicator with preserved input
+func ThinkingStateWithInput(inputView string, spinner string) string {
+	var s strings.Builder
+
+	// Show input with prompt symbol
+	s.WriteString(promptSymbol)
+	s.WriteString(" ")
+
+	// Handle multi-line alignment by replacing newlines with proper indentation
+	lines := strings.Split(inputView, "\n")
+	for i, line := range lines {
+		if i > 0 {
+			s.WriteString("\n  ") // 2 spaces to align with prompt symbol + space
+		}
+		s.WriteString(line)
+	}
+
+	// Add thinking indicator
+	s.WriteString("\n\n")
+	if spinner != "" {
+		s.WriteString(promptStyle.Render(spinner))
+		s.WriteString(" ")
+	}
+	s.WriteString(thinkingStyle.Render("Thinking..."))
 	s.WriteString("\n")
 
 	return s.String()
@@ -136,6 +166,11 @@ func ErrorMessage(err error) string {
 		return ""
 	}
 	return "\n\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render(fmt.Sprintf("Error: %v", err))
+}
+
+// ThinkingText renders just the thinking text without prompt
+func ThinkingText() string {
+	return thinkingStyle.Render(" Thinking...")
 }
 
 // InfoMessage renders info messages

--- a/internal/ui/terminal/model.go
+++ b/internal/ui/terminal/model.go
@@ -74,7 +74,7 @@ func NewModel(provider llm.Provider, cfg *config.Config) *Model {
 
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("87")) // Match Rigel blue
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("87")).Bold(true) // Same as prompt symbol
 
 	// Initialize history manager
 	histManager, err := history.NewManager()

--- a/internal/ui/terminal/update.go
+++ b/internal/ui/terminal/update.go
@@ -244,40 +244,46 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case command.Result:
-		m.chatState.SetThinking(false)
 		if msg.Error != nil {
+			m.chatState.SetThinking(false)
 			m.chatState.SetError(msg.Error)
 		} else {
 			switch msg.Type {
 			case "clear_input_history":
 				// Clear input history
+				m.chatState.SetThinking(false)
 				m.inputHistory = []string{}
 				m.historyIndex = -1
 				m.currentInput = ""
 				m.chatState.AddExchange(m.chatState.GetCurrentPrompt(), "Command history cleared successfully.")
 				m.chatState.ClearCurrentPrompt()
 			case "request":
-				// Handle normal prompts (non-commands)
+				// Handle normal prompts (non-commands) - keep thinking state ON
 				return m, handlers.RequestResponse(msg.Prompt, m.llmState, m.chatState)
 			case "model_selector":
+				m.chatState.SetThinking(false)
 				if msg.ModelSelector != nil {
 					return m, func() tea.Msg { return *msg.ModelSelector }
 				}
 			case "provider_selector":
+				m.chatState.SetThinking(false)
 				if msg.ProviderSelector != nil {
 					return m, func() tea.Msg { return *msg.ProviderSelector }
 				}
 			case "status":
+				m.chatState.SetThinking(false)
 				if msg.StatusInfo != nil {
 					return m, func() tea.Msg { return *msg.StatusInfo }
 				}
 			case "quit":
+				m.chatState.SetThinking(false)
 				m.quitting = true
 				return m, tea.Quit
 			case "clear":
-				// Clear handled above by SetThinking(false)
+				m.chatState.SetThinking(false)
 				return m, nil
 			default:
+				m.chatState.SetThinking(false)
 				if msg.Content != "" {
 					m.chatState.AddExchange(m.chatState.GetCurrentPrompt(), msg.Content)
 					m.chatState.ClearCurrentPrompt()

--- a/internal/ui/terminal/view.go
+++ b/internal/ui/terminal/view.go
@@ -28,17 +28,26 @@ func (m Model) View() string {
 
 	// Display provider selection interface if in provider selection mode
 	if m.llmState.IsProviderSelectionActive() {
-		return render.ProviderSelector(m.llmState.GetAvailableProviders(), m.llmState.GetSelectedProviderIndex())
+		s.WriteString(render.ProviderSelector(m.llmState.GetAvailableProviders(), m.llmState.GetSelectedProviderIndex()))
+		s.WriteString(render.InfoMessage(m.infoMessage))
+		s.WriteString(render.ErrorMessage(m.chatState.GetError()))
+		return s.String()
 	}
 
 	// Display model selection interface if in model selection mode
 	if m.llmState.IsModelSelectionActive() {
-		return render.ModelSelector(m.llmState.GetFilteredModels(), m.llmState.GetSelectedModelIndex(), m.llmState.GetModelFilter())
+		s.WriteString(render.ModelSelector(m.llmState.GetFilteredModels(), m.llmState.GetSelectedModelIndex(), m.llmState.GetModelFilter()))
+		s.WriteString(render.InfoMessage(m.infoMessage))
+		s.WriteString(render.ErrorMessage(m.chatState.GetError()))
+		return s.String()
 	}
 
 	// Display thinking state
 	if m.chatState.IsThinking() {
 		s.WriteString(render.ThinkingState(m.chatState.GetCurrentPrompt(), m.spinner.View()))
+		s.WriteString(render.InfoMessage(m.infoMessage))
+		s.WriteString(render.ErrorMessage(m.chatState.GetError()))
+		return s.String()
 	}
 
 	// Display input prompt and suggestions


### PR DESCRIPTION
## Summary
• Fixed thinking state not displaying during LLM processing
• Resolved spinner color mismatch with prompt symbol
• Improved terminal rendering reliability

## Test plan
- [x] Verify thinking state displays with animated spinner
- [x] Confirm spinner matches prompt symbol color (Color 87, Bold)
- [x] Test message flow: input → thinking state → response
- [x] Validate no debug output in final build

🤖 Generated with [Claude Code](https://claude.ai/code)