### PR TITLE
fix: Implement actual repository analysis in /init command

### DIFF
--- a/internal/command/completion.go
+++ b/internal/command/completion.go
@@ -15,7 +15,7 @@ func (h *CompletionHandler) UpdateCompletions(inputValue string) ([]string, bool
 	completions := []string{}
 	showCompletions := false
 
-	// Check if the input starts with /
+	// Check if the input starts with / (without leading spaces)
 	if strings.HasPrefix(inputValue, "/") {
 		prefix := strings.ToLower(inputValue)
 		for _, cmd := range AvailableCommands {

--- a/internal/command/completion_test.go
+++ b/internal/command/completion_test.go
@@ -1,0 +1,65 @@
+package command
+
+import "testing"
+
+func TestCompletionHandler_UpdateCompletions_SpaceHandling(t *testing.T) {
+	handler := NewCompletionHandler()
+
+	tests := []struct {
+		name        string
+		input       string
+		expectShow  bool
+		expectCount int
+	}{
+		{
+			name:        "command without space",
+			input:       "/he",
+			expectShow:  true,
+			expectCount: 1, // /help
+		},
+		{
+			name:        "command with leading space",
+			input:       " /he",
+			expectShow:  false, // Should not show completions
+			expectCount: 0,
+		},
+		{
+			name:        "command with multiple leading spaces",
+			input:       "  /he",
+			expectShow:  false, // Should not show completions
+			expectCount: 0,
+		},
+		{
+			name:        "text with slash in middle",
+			input:       "hello/he",
+			expectShow:  false,
+			expectCount: 0,
+		},
+		{
+			name:        "just slash",
+			input:       "/",
+			expectShow:  true,
+			expectCount: len(AvailableCommands), // All commands should match
+		},
+		{
+			name:        "space then slash",
+			input:       " /",
+			expectShow:  false,
+			expectCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			completions, showCompletions := handler.UpdateCompletions(tt.input)
+
+			if showCompletions != tt.expectShow {
+				t.Errorf("UpdateCompletions(%q) showCompletions = %v, want %v", tt.input, showCompletions, tt.expectShow)
+			}
+
+			if len(completions) != tt.expectCount {
+				t.Errorf("UpdateCompletions(%q) completions count = %d, want %d", tt.input, len(completions), tt.expectCount)
+			}
+		})
+	}
+}

--- a/internal/command/handler.go
+++ b/internal/command/handler.go
@@ -12,9 +12,19 @@ import (
 // HandleCommand processes a command and returns the result
 // This function is stateless and doesn't need a Handler struct
 func HandleCommand(command string, llmState *state.LLMState, chatState *state.ChatState, cfg *config.Config, historyManager *history.Manager, inputHistory []string) Result {
+	// Only treat as command if it starts with / without any leading whitespace
+	if !strings.HasPrefix(command, "/") {
+		return Result{
+			Type:   "request",
+			Prompt: command,
+		}
+	}
+
+	// Use trimmed version for command processing
+	command = strings.TrimSpace(command)
 	switch command {
 	case "/init":
-		return analyzeRepository()
+		return analyzeRepository(llmState)
 
 	case "/model":
 		return showModelSelector(llmState)

--- a/internal/command/handler_test.go
+++ b/internal/command/handler_test.go
@@ -1,0 +1,60 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mizzy/rigel/internal/config"
+	"github.com/mizzy/rigel/internal/state"
+)
+
+func TestHandleCommand_SpaceHandling(t *testing.T) {
+	llmState := state.NewLLMState()
+	chatState := state.NewChatState()
+	cfg := &config.Config{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string // "request" for regular prompt, "response" for command
+	}{
+		{
+			name:     "command without space",
+			input:    "/help",
+			expected: "response",
+		},
+		{
+			name:     "command with leading space",
+			input:    " /help",
+			expected: "request", // Should be treated as regular prompt
+		},
+		{
+			name:     "command with multiple leading spaces",
+			input:    "  /help",
+			expected: "request", // Should be treated as regular prompt
+		},
+		{
+			name:     "text containing slash",
+			input:    "hello/world",
+			expected: "request",
+		},
+		{
+			name:     "text with space before slash",
+			input:    "hello /world",
+			expected: "request",
+		},
+		{
+			name:     "valid command with trailing content",
+			input:    "/help me",
+			expected: "response", // Unknown command, but still command
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HandleCommand(tt.input, llmState, chatState, cfg, nil, []string{})
+			if result.Type != tt.expected {
+				t.Errorf("HandleCommand(%q) = %q, want %q", tt.input, result.Type, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/command/types.go
+++ b/internal/command/types.go
@@ -6,10 +6,11 @@ import (
 
 // Result represents the result of command execution
 type Result struct {
-	Type    string // "response", "model_selector", "provider_selector", "status", "quit", "clear", "request"
+	Type    string // "response", "model_selector", "provider_selector", "status", "quit", "clear", "request", "async"
 	Error   error
-	Content string // Text response content
-	Prompt  string // For "request" type - the prompt to send to LLM
+	Content string        // Text response content
+	Prompt  string        // For "request" type - the prompt to send to LLM
+	AsyncFn func() Result // For "async" type - function to execute asynchronously
 
 	// Type-specific data (only one should be set based on Type)
 	ModelSelector    *ModelSelectorMsg

--- a/internal/ui/terminal/update.go
+++ b/internal/ui/terminal/update.go
@@ -162,8 +162,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.showCompletions = false
 
 					// Handle the command
-					trimmedPrompt := strings.TrimSpace(m.chatState.GetCurrentPrompt())
-					result := command.HandleCommand(trimmedPrompt, m.llmState, m.chatState, m.config, m.historyManager, m.inputHistory)
+					cmdPrompt := m.chatState.GetCurrentPrompt()
+					result := command.HandleCommand(cmdPrompt, m.llmState, m.chatState, m.config, m.historyManager, m.inputHistory)
 					cmd := func() tea.Msg { return result }
 					return m, tea.Batch(cmd, m.spinner.Tick)
 				}
@@ -190,8 +190,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.showCompletions = false
 
 				// Handle commands
-				trimmedPrompt := strings.TrimSpace(m.chatState.GetCurrentPrompt())
-				result := command.HandleCommand(trimmedPrompt, m.llmState, m.chatState, m.config, m.historyManager, m.inputHistory)
+				cmdPrompt := m.chatState.GetCurrentPrompt()
+				result := command.HandleCommand(cmdPrompt, m.llmState, m.chatState, m.config, m.historyManager, m.inputHistory)
 				cmd := func() tea.Msg { return result }
 				return m, tea.Batch(cmd, m.spinner.Tick)
 			}
@@ -249,6 +249,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.chatState.SetError(msg.Error)
 		} else {
 			switch msg.Type {
+			case "async":
+				// Keep thinking state ON and execute async function
+				if msg.AsyncFn != nil {
+					asyncCmd := func() tea.Msg {
+						return msg.AsyncFn()
+					}
+					return m, asyncCmd
+				}
 			case "clear_input_history":
 				// Clear input history
 				m.chatState.SetThinking(false)


### PR DESCRIPTION
## Summary
- Implement actual repository analysis instead of placeholder message in `/init` command
- Add async command execution to properly display spinner during long-running operations
- Integrate existing analyzer package to generate comprehensive AGENTS.md content

## Test plan
- [x] Build and run the application
- [x] Execute `/init` command to verify spinner shows during execution
- [x] Verify AGENTS.md is properly generated with LLM-analyzed content
- [x] Confirm existing functionality remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)