### PR TITLE
docs: Update CLAUDE.md with latest architecture and translate uitest README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Build and Run
 ```bash
-# Build the binary
-make build                    # Output to ./bin/rigel
-go build -o rigel cmd/rigel/main.go  # Direct build
+# Build the binary with version info
+make build                    # Output to ./bin/rigel with version/git info
+make deps                     # Download and tidy dependencies first
+go build -o rigel cmd/rigel/main.go  # Direct build (no version info)
 
 # Run in development mode
-make run                      # Run without building
-go run cmd/rigel/main.go      # Direct run
-make dev                      # Build and run
+make run                      # Run without building (go run cmd/rigel/main.go)
+make dev                      # Download deps + build + run
+PROVIDER=ollama ./bin/rigel   # Run with specific provider
+
+# Run with different UI modes
+./bin/rigel --termflow        # Use termflow UI (preserves scrollback)
+./bin/rigel                   # Use bubbletea UI (default)
+
+# Security options
+./bin/rigel --sandbox         # Force enable sandbox mode (macOS)
+./bin/rigel --no-sandbox      # Disable sandbox mode
 
 # Install globally
-make install                  # Install to $GOPATH/bin
+make install                  # Install to $GOPATH/bin with version info
 go install ./cmd/rigel
 ```
 
@@ -26,16 +35,24 @@ go install ./cmd/rigel
 make test                     # Verbose test output
 go test ./...                 # Standard test run
 
-# Run tests for specific package
-go test ./internal/llm -v    # Test LLM package
-go test ./internal/ui -v     # Test UI package
+# Run tests for specific packages
+go test ./internal/llm -v              # Test LLM package
+go test ./internal/ui/terminal -v      # Test Terminal UI
+go test ./internal/ui/termflow -v      # Test Termflow UI
+go test ./lib/termflow -v              # Test Termflow library
 
 # Test with coverage
 make test-coverage            # Coverage report
 go test -cover ./...          # Direct coverage
 
-# Run single test
+# Run specific tests
 go test -run TestAnthropicProvider ./internal/llm
+go test -run TestCtrlCBehavior ./internal/ui/termflow
+go test -run TestHistoryPersistence ./internal/ui/termflow
+
+# Integration and UI tests (requires RIGEL_TEST_MODE=1)
+RIGEL_TEST_MODE=1 PROVIDER=ollama go test ./internal/ui/termflow -v
+RIGEL_TEST_MODE=1 PROVIDER=ollama go test ./lib/termflow/uitest -v
 
 # Integration tests (requires API keys)
 ANTHROPIC_API_KEY=xxx go test ./internal/llm -run TestAnthropicProvider_Generate
@@ -57,74 +74,189 @@ staticcheck ./...
 pre-commit run --all-files
 ```
 
+### Git Branch Management
+
+**After PR Merge - Always Update Main Branch:**
+```bash
+# Switch to main and pull latest changes
+git checkout main
+git pull
+
+# Clean up local branches (delete merged feature branch)
+git branch -D feature/branch-name
+
+# Remove stale remote branch references
+git remote prune origin
+```
+
+**Create Feature Branch Workflow:**
+```bash
+# Start from updated main
+git checkout main
+git pull
+
+# Create and switch to new feature branch
+git checkout -b feature/descriptive-name
+
+# After development, push and create PR
+git push -u origin feature/descriptive-name
+gh pr create --title "feat: Description" --body "Detailed description"
+```
+
 ## High-Level Architecture
 
-### Core Components
+### Dual UI System
 
-**Terminal UI System** (`internal/ui/terminal/`)
-- `model.go`: Main chat model managing state, input handling, and rendering
-- `commands.go`: Slash command handlers (`/init`, `/model`, `/provider`, `/help`)
-- Provider and model selection are handled through interactive modal interfaces
-- Uses Bubbletea framework for terminal UI with inline mode (no alternate screen)
+**Termflow UI** (`lib/termflow/` + `internal/ui/termflow/`)
+- Custom terminal library that preserves scrollback buffer
+- Raw terminal mode with advanced line editing capabilities
+- Multiline input support with `...` syntax
+- History navigation (Up/Down arrows) with file persistence
+- Tab completion for commands and models
+- Two-press Ctrl+C exit pattern (first press cancels input, second exits)
+- PTY-based testing framework (`lib/termflow/uitest/`)
+
+**Terminal UI** (`internal/ui/terminal/`)
+- Traditional Bubbletea-based interface with inline mode
+- Modal interfaces for provider/model selection
+- Spinner animations and structured output
+- No alternate screen mode (preserves terminal history)
+
+### Core Systems
+
+**Agent System** (`internal/agent/`)
+- Context-aware AI agent with tool integration
+- Task detection and automatic execution
+- Progress tracking with UI feedback
+- Conversation memory management and state persistence
+
+**Tool Integration** (`internal/tools/`)
+- `file_tool.go`: File operations (read, write, list, exists, delete)
+- `code_tool.go`: Code analysis and manipulation tools
+- Automatic tool selection based on prompt analysis
+- Tool execution results integrated into AI responses
 
 **LLM Provider System** (`internal/llm/`)
 - `provider.go`: Common interface for all LLM providers
-- `anthropic.go`: Anthropic implementation with API model listing and fallback
-- `ollama.go`: Ollama local model support
-- Provider switching happens dynamically through config updates and provider recreation
+- `anthropic.go`: Anthropic Claude models with API model listing
+- `ollama.go`: Local Ollama model support
+- `agents_loader.go`: Loads AGENTS.md context for repository understanding
+- Provider switching happens dynamically at runtime
 
-**Command Flow**
-1. User types `/provider` or `/model` command
-2. Command handler fetches available options (from API or config)
-3. Interactive selector UI is shown (arrow keys to navigate, Enter to select)
-4. On selection, provider/model is switched and config updated
-5. Chat continues with new provider/model
+**Command System** (`internal/command/`)
+- Centralized command processing with tab completion
+- Available commands: `/init`, `/model`, `/provider`, `/status`, `/help`, `/clear`, `/clearhistory`, `/exit`, `/quit`
+- Async command execution with progress feedback
+- Command history persistence
+
+**State Management**
+- `internal/state/chat.go`: Chat history and session state
+- `internal/state/llm.go`: LLM configuration and provider selection
+- `internal/history/`: Persistent command and chat history
+- Cross-session state preservation
+
+**Security System** (`internal/sandbox/`)
+- macOS sandbox support using `sandbox-exec`
+- Restricts file operations to current directory and `.rigel` folder
+- Auto-enabled on macOS, can be disabled with `--no-sandbox`
 
 ### Key Design Patterns
 
-**Provider Selection**:
-- Runtime provider switching without restart
-- Config object passed to ChatModel for dynamic updates
-- Provider interface allows transparent switching between Anthropic/Ollama
+**UI Mode Selection**:
+- `--termflow` flag enables termflow UI (recommended for scrollback preservation)
+- Default uses bubbletea UI for compatibility
+- Both UIs share same agent/tool backend systems
 
-**Model Discovery**:
-- Anthropic: Attempts API call to `/v1/models`, falls back to hardcoded list
-- Ollama: Uses local API to list installed models
-- Default models: Claude Sonnet 4 for Anthropic, gpt-oss:20b for Ollama
+**Provider and Model Management**:
+- Default provider: `ollama` for out-of-box experience
+- Runtime provider switching without application restart
+- Model discovery through provider APIs with fallback lists
+- Configuration validation ensures required API keys are present
 
-**State Management**:
-- ChatModel maintains provider, config, and UI state
-- Selection modes (provider/model) are exclusive states
-- ESC key properly exits selection modes and resets thinking state
+**Tool Integration Pattern**:
+- Tools automatically selected based on prompt analysis
+- File operations sandboxed to current directory
+- Tool results seamlessly integrated into conversation flow
+- Progress feedback during long-running operations
+
+**Testing Architecture**:
+- PTY-based testing for terminal UI interactions
+- Mock providers for isolated LLM testing
+- `RIGEL_TEST_MODE=1` environment variable enables test mode
+- Comprehensive test coverage for UI behaviors and tool integration
 
 ### Configuration
 
 **Environment Variables** (`.env` file or shell):
 ```
-PROVIDER=anthropic|ollama
-ANTHROPIC_API_KEY=xxx
+PROVIDER=ollama|anthropic        # Default: ollama
+ANTHROPIC_API_KEY=xxx           # Required for Anthropic provider
 MODEL=claude-sonnet-4-20250514  # Optional, uses provider defaults
-OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_BASE_URL=http://localhost:11434  # Default Ollama endpoint
+RIGEL_TEST_MODE=1               # Enable test mode for UI testing
 ```
 
 **Provider Defaults**:
-- Anthropic: `claude-sonnet-4-20250514`
-- Ollama: `gpt-oss:20b`
-- OpenAI (planned): `gpt-4-turbo-preview`
+- **Ollama** (default): `gpt-oss:20b`
+- **Anthropic**: `claude-sonnet-4-20250514`
+- **OpenAI** (planned): `gpt-4-turbo-preview`
 
-### Repository Analysis
+**Command Line Flags**:
+```bash
+--termflow      # Use termflow UI (recommended)
+--sandbox       # Force enable sandbox mode
+--no-sandbox    # Disable sandbox mode
+--version       # Show version information
+```
+
+### Repository Analysis and Agent Context
 
 The `/init` command generates `AGENTS.md` by:
-1. Analyzing repository structure and code patterns
-2. Using LLM to generate comprehensive documentation
-3. Prepending AGENTS.md content to system prompts automatically
+1. Analyzing repository structure, dependencies, and code patterns
+2. Using LLM to generate comprehensive codebase documentation
+3. Automatically prepending AGENTS.md content to system prompts
+4. Enabling context-aware responses about the codebase
 
-This context helps the AI understand the codebase structure when answering questions.
+This provides the AI agent with deep understanding of:
+- Project architecture and design patterns
+- Build and test workflows
+- Available tools and frameworks
+- Code conventions and best practices
+
+### Tool Integration System
+
+**Automatic Tool Detection**:
+- Agent analyzes user prompts to determine required tools
+- File operations, code analysis, and repository queries handled automatically
+- Progress feedback shown during tool execution
+- Tool results integrated seamlessly into conversation
+
+**Available Tools**:
+- **File Tools**: Read, write, list, delete files (sandboxed to current directory)
+- **Code Tools**: Code analysis, pattern detection, refactoring assistance
+- **Repository Tools**: Git integration, dependency analysis, structure mapping
 
 ## Important Implementation Details
 
-- **Terminal Colors**: Uses Rigel theme (blue #5793ff for highlights)
-- **Input Handling**: Alt+Enter for multiline, Tab for command completion
-- **Error Recovery**: API failures fall back to hardcoded model lists
-- **Testing**: Most tests mock LLM responses with httptest
-- **Security**: No API keys in code, loaded from environment only
+### Terminal UI Specifics
+- **Termflow Mode**: Preserves scrollback, multiline with `...`, history navigation
+- **Bubbletea Mode**: Modal interfaces, spinner feedback, structured output
+- **Colors**: Rigel theme with blue (#5793ff) highlights
+- **Input**: Tab completion, Alt+Enter for multiline (bubbletea only)
+
+### Security and Sandboxing
+- **macOS Sandbox**: Auto-enabled, restricts writes to current directory + `.rigel/`
+- **API Security**: Keys loaded from environment, never stored in code
+- **Tool Sandboxing**: File operations restricted to project directory
+
+### Testing Infrastructure
+- **Mock Testing**: LLM providers mocked with `httptest` for isolation
+- **PTY Testing**: Terminal interactions tested with pseudoterminals
+- **Integration Testing**: Full agent workflows with `RIGEL_TEST_MODE=1`
+- **UI Testing**: Both termflow and bubbletea UIs comprehensively tested
+
+### Performance and Error Handling
+- **Provider Fallbacks**: API failures gracefully fall back to hardcoded model lists
+- **State Persistence**: Chat and command history saved across sessions
+- **Memory Management**: Conversation context managed for optimal performance
+- **Async Operations**: Long-running tasks with progress feedback and cancellation

--- a/lib/termflow/uitest/README.md
+++ b/lib/termflow/uitest/README.md
@@ -1,54 +1,54 @@
 # Termflow UI Testing Framework
 
-Playwright風の端末アプリケーション自動テストフレームワークです。
+A Playwright-style automated testing framework for terminal applications.
 
-## 概要
+## Overview
 
-このフレームワークは、termflowベースのアプリケーションのUIを自動テストするためのツールです。実際の端末環境を模擬し、ユーザーインタラクションをシミュレートして、出力を検証できます。
+This framework provides tools for automated UI testing of termflow-based applications. It simulates real terminal environments, allowing you to simulate user interactions and validate outputs.
 
-## 機能
+## Features
 
-### 1. **TerminalTest** - 仮想端末テスト
-- 実際のPTY（pseudo-terminal）を使用
-- リアルなキーボード入力シミュレーション
-- ANSI エスケープシーケンス対応
-- スピナーアニメーション検証
+### 1. **TerminalTest** - Virtual Terminal Testing
+- Uses actual PTY (pseudo-terminal)
+- Real keyboard input simulation
+- ANSI escape sequence support
+- Spinner animation validation
 
-### 2. **MockIO** - 軽量単体テスト
-- I/O をモックしてコンポーネント単位でテスト
-- 高速実行
-- 出力フォーマット検証
+### 2. **MockIO** - Lightweight Unit Testing
+- Mock I/O for component-level testing
+- Fast execution
+- Output format validation
 
-## 使い方
+## Usage
 
-### 基本的なテスト
+### Basic Testing
 
 ```go
 func TestMyApp(t *testing.T) {
-    // アプリケーションを起動
+    // Start application
     tt, err := NewTerminalTest(t, "./my-app", "--termflow")
     if err != nil {
         t.Fatalf("Failed to start: %v", err)
     }
     defer tt.Close()
 
-    // 起動を待つ
+    // Wait for startup
     tt.Wait(500 * time.Millisecond)
 
-    // ウェルカムメッセージを確認
+    // Verify welcome message
     tt.ExpectWelcome()
     tt.ExpectPrompt()
 
-    // ユーザー入力をシミュレート
+    // Simulate user input
     tt.Type("hello world")
 
-    // 応答を待って検証
+    // Wait for response and validate
     tt.Wait(1 * time.Second)
     tt.ExpectOutput("Hello!")
 }
 ```
 
-### 高度なテスト
+### Advanced Testing
 
 ```go
 func TestSpinnerAndCtrlC(t *testing.T) {
@@ -60,25 +60,25 @@ func TestSpinnerAndCtrlC(t *testing.T) {
 
     tt.Wait(500 * time.Millisecond)
 
-    // 長い処理をトリガー
+    // Trigger long-running task
     tt.Type("complex task")
 
-    // スピナーアニメーションを確認
+    // Verify spinner animation
     tt.ExpectSpinner()
     tt.ExpectThinking()
 
-    // Ctrl+C のテスト
+    // Test Ctrl+C behavior
     tt.SendCtrlC()
     tt.ExpectOutput("Press Ctrl+C again to exit")
-    tt.ExpectNoCtrlC() // ^C文字が表示されないことを確認
+    tt.ExpectNoCtrlC() // Verify ^C characters are not displayed
 
-    // 2回目のCtrl+C
+    // Second Ctrl+C
     tt.SendCtrlC()
     tt.ExpectOutput("Goodbye!")
 }
 ```
 
-### マルチライン入力テスト
+### Multiline Input Testing
 
 ```go
 func TestMultilineInput(t *testing.T) {
@@ -90,21 +90,21 @@ func TestMultilineInput(t *testing.T) {
 
     tt.Wait(500 * time.Millisecond)
 
-    // マルチライン入力をトリガー
+    // Trigger multiline input
     tt.SendKeys("Write a function...")
     tt.SendEnter()
 
-    // 継続プロンプトを確認
+    // Verify continuation prompt
     tt.ExpectOutput("Continue typing")
-    tt.ExpectPattern(`\d+>`) // "2>" のような行番号プロンプト
+    tt.ExpectPattern(`\d+>`) // Line number prompt like "2>"
 
-    // 追加の行を入力
+    // Enter additional lines
     tt.SendKeys("def hello():")
     tt.SendEnter()
     tt.SendKeys("    print('Hello')")
     tt.SendEnter()
 
-    // 終了マーカー
+    // End marker
     tt.SendKeys(".")
     tt.SendEnter()
 
@@ -112,48 +112,48 @@ func TestMultilineInput(t *testing.T) {
 }
 ```
 
-## 利用可能なメソッド
+## Available Methods
 
-### 入力操作
-- `SendKeys(string)` - キー入力送信
-- `Type(string)` - テキスト入力 + Enter
-- `SendEnter()` - Enter キー
-- `SendCtrlC()` - Ctrl+C
-- `Wait(duration)` - 待機
+### Input Operations
+- `SendKeys(string)` - Send key input
+- `Type(string)` - Type text + Enter
+- `SendEnter()` - Send Enter key
+- `SendCtrlC()` - Send Ctrl+C
+- `Wait(duration)` - Wait for specified duration
 
-### 出力検証
-- `ExpectOutput(string)` - テキストが含まれることを確認
-- `ExpectPattern(regex)` - 正規表現マッチを確認
-- `ExpectPrompt()` - プロンプト（✦）の存在確認
-- `ExpectWelcome()` - ウェルカムメッセージ確認
-- `ExpectSpinner()` - スピナーアニメーション確認
-- `ExpectThinking()` - "Thinking..." メッセージ確認
-- `ExpectNoCtrlC()` - ^C 文字が表示されないことを確認
+### Output Validation
+- `ExpectOutput(string)` - Verify text is present in output
+- `ExpectPattern(regex)` - Verify regex pattern matches
+- `ExpectPrompt()` - Verify prompt (✦) is present
+- `ExpectWelcome()` - Verify welcome message
+- `ExpectSpinner()` - Verify spinner animation
+- `ExpectThinking()` - Verify "Thinking..." message
+- `ExpectNoCtrlC()` - Verify ^C characters are not displayed
 
-### デバッグ
-- `GetOutput()` - 生出力取得（ANSIコード含む）
-- `GetVisibleOutput()` - 表示テキスト取得（ANSIコード除去）
-- `Screenshot()` - 現在の画面状態をフォーマット表示
-- `GetLines()` - 行ごとの出力配列
+### Debugging
+- `GetOutput()` - Get raw output (including ANSI codes)
+- `GetVisibleOutput()` - Get visible text (ANSI codes removed)
+- `Screenshot()` - Format and display current screen state
+- `GetLines()` - Get output as array of lines
 
-## テスト実行
+## Running Tests
 
 ```bash
-# 基本テスト
-go test ./lib/termflow/testing
+# Basic tests
+go test ./lib/termflow/uitest
 
-# 統合テスト（バイナリビルド必要）
+# Integration tests (requires binary build)
 go build -o /tmp/rigel-test cmd/rigel/main.go
-go test ./lib/termflow/testing -v
+go test ./lib/termflow/uitest -v
 
-# ベンチマーク
-go test -bench=. ./lib/termflow/testing
+# Benchmarks
+go test -bench=. ./lib/termflow/uitest
 
-# 短時間テストのみ（統合テストをスキップ）
-go test -short ./lib/termflow/testing
+# Short tests only (skip integration tests)
+go test -short ./lib/termflow/uitest
 ```
 
-## アーキテクチャ
+## Architecture
 
 ```
 ┌─────────────────────────────────────┐
@@ -168,19 +168,19 @@ go test -short ./lib/termflow/testing
 └─────────────────────────────────────┘
 ```
 
-## 制限事項
+## Limitations
 
-- Linux/macOS での PTY サポートが必要
-- Windows では制限あり（WSL推奨）
-- アプリケーションのビルドが必要
-- タイミングに依存するテストは不安定になる可能性
+- Requires PTY support on Linux/macOS
+- Limited Windows support (WSL recommended)
+- Application build required
+- Timing-dependent tests may be unstable
 
-## ベストプラクティス
+## Best Practices
 
-1. **適切な待機時間**: `Wait()` で十分な時間を設ける
-2. **スクリーンショット活用**: デバッグ時は `Screenshot()` を使用
-3. **段階的検証**: 大きな動作を小さなステップに分けて検証
-4. **環境の初期化**: 各テストで新しいTerminalTestインスタンス使用
-5. **エラーハンドリング**: defer で必ずCloseを呼ぶ
+1. **Proper Wait Times**: Use `Wait()` with sufficient duration
+2. **Use Screenshots**: Use `Screenshot()` for debugging
+3. **Step-by-Step Validation**: Break large operations into small verification steps
+4. **Environment Initialization**: Use new TerminalTest instance for each test
+5. **Error Handling**: Always call Close() with defer
 
-このフレームワークにより、termflowアプリケーションの品質を自動テストで保証できます。
+This framework enables automated quality assurance for termflow applications through comprehensive testing.


### PR DESCRIPTION
## Summary

- Update CLAUDE.md with comprehensive documentation of the current Rigel architecture
- Translate the termflow uitest framework README from Japanese to English  
- Document new features including dual UI system, agent integration, and security sandbox

## Changes Made

### CLAUDE.md Updates
- **Dual UI System**: Document both termflow and bubbletea UI modes with usage examples
- **Agent System**: Add comprehensive documentation of context-aware AI agent with tool integration
- **Security System**: Document macOS sandbox support and security features  
- **Enhanced Testing**: Update testing infrastructure documentation with PTY testing patterns
- **Build & Commands**: Update build commands, flags (`--termflow`, `--sandbox`), and environment variables
- **Architecture**: Completely rewrite architecture section to reflect current dual-UI design
- **Tool Integration**: Document automatic tool detection and file operation capabilities

### Termflow uitest README Translation
- Complete translation from Japanese to English
- Maintain all technical content and code examples
- Update documentation structure and formatting for consistency
- Document Playwright-style testing framework for terminal applications

## Test Plan

- [x] Verify CLAUDE.md accurately reflects current codebase structure
- [x] Confirm all command examples and flags are correct  
- [x] Validate translated README maintains technical accuracy
- [x] Check that documentation formatting is consistent

🤖 Generated with [Claude Code](https://claude.ai/code)