### PR TITLE
chore(gitignore): ignore Go build caches (.gocache, .gomodcache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ dist/
 build/
 bin/
 
+# Local Go build caches
+.gocache/
+.gomodcache/
+lib/.gocache/
+lib/.gomodcache/
+
 # Debug files
 debug
 __debug_bin


### PR DESCRIPTION
This PR updates .gitignore to exclude local Go build caches so they are not accidentally committed.\n\n- Add entries: `.gocache/`, `.gomodcache/`, plus `lib/.gocache/` and `lib/.gomodcache/` for nested builds.\n- No code changes. Safe to merge anytime.