### PR TITLE
pre-commit: restrict gofmt/goimports to staged files, exclude .gomodcache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,23 @@
 # See https://pre-commit.com for more information
+# Exclude non-repo directories from all hooks
+exclude: ^(\.gomodcache/|vendor/|bin/|third_party/)
 repos:
   # Go hooks
   - repo: local
     hooks:
       - id: go-fmt
         name: go fmt
-        entry: bash -c 'gofmt -l -w .'
+        entry: gofmt
+        args: ["-l", "-w"]
         language: system
         types: [go]
-        pass_filenames: false
 
       - id: go-imports
         name: goimports
-        entry: bash -c 'goimports -l -w .'
+        entry: goimports
+        args: ["-l", "-w"]
         language: system
         types: [go]
-        pass_filenames: false
 
       - id: go-vet
         name: go vet


### PR DESCRIPTION
Summary
- Prevent permission errors during pre-commit by limiting formatters to staged files and excluding external caches.

Changes
- Run `gofmt` and `goimports` only on staged Go files (file-based execution).
- Add a top-level exclude for `.gomodcache/`, `vendor/`, `bin/`, and `third_party/`.
- Keep `go vet`, `staticcheck`, and `go test` as repo-wide checks.

Motivation & Context
- A previous commit was blocked when hooks attempted to format files under `.gomodcache`, causing permission denied errors.

How Tested
- With pre-commit installed, modified a Go file and committed: formatters ran on the changed file(s) only.
- Changes under `.gomodcache/` are ignored by hooks.

Impact
- Only the scope of formatting changes; analysis and tests remain unchanged.
