### PR TITLE
termflow: interactive completion navigation (Up/Down + Tab/Enter)

### DIFF
--- a/lib/termflow/completion.go
+++ b/lib/termflow/completion.go
@@ -157,7 +157,8 @@ func (cs *CompletionSelector) RenderCompletions(maxItems int) string {
 	}
 
 	var result strings.Builder
-	result.WriteString("\nCompletions:\n")
+	// Ensure each printed line returns to column 0 with \r
+	result.WriteString("\rCompletions:\n")
 
 	start := 0
 	end := len(cs.items)
@@ -185,6 +186,7 @@ func (cs *CompletionSelector) RenderCompletions(maxItems int) string {
 			marker = "▶ "
 		}
 
+		result.WriteString("\r")
 		result.WriteString(marker)
 		result.WriteString(item.Text)
 

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -416,10 +416,8 @@ func (le *LineEditor) refreshDisplay() {
 
 // showOrUpdateCompletions renders the current completion list below the input while preserving cursor
 func (le *LineEditor) showOrUpdateCompletions() {
-	// Clear previous list if present
-	if le.completionLines > 0 {
-		le.clearCompletions()
-	}
+	// Aggressively clear any prior completion area to avoid duplicates/blank lines
+	le.clearCompletionArea(24)
 
 	// Save cursor position
 	fmt.Fprint(le.client.output, "\0337")
@@ -456,10 +454,20 @@ func (le *LineEditor) clearCompletions() {
 	if le.completionLines <= 0 {
 		return
 	}
+	le.clearCompletionArea(le.completionLines)
+	le.completionLines = 0
+}
+
+// clearCompletionArea clears up to maxLines below the input block, starting one line beneath it
+// This is more robust against earlier versions that may have left stray blank lines.
+func (le *LineEditor) clearCompletionArea(maxLines int) {
+	if maxLines <= 0 {
+		maxLines = 1
+	}
 	// Save cursor
 	fmt.Fprint(le.client.output, "\0337")
 
-	// Move to the bottom of the input block and down to the first completion line
+	// Move to the bottom of the input block
 	lines := strings.Split(le.line, "\n")
 	textBeforeCursor := le.line[:le.cursor]
 	linesBeforeCursor := strings.Split(textBeforeCursor, "\n")
@@ -468,19 +476,19 @@ func (le *LineEditor) clearCompletions() {
 	if down > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", down)
 	}
+	// Move to first completion line
 	fmt.Fprint(le.client.output, "\033[1B\r")
 
-	// Clear exactly the number of lines previously drawn
-	for i := 0; i < le.completionLines; i++ {
+	// Clear requested number of lines
+	for i := 0; i < maxLines; i++ {
 		fmt.Fprint(le.client.output, "\033[K")
-		if i < le.completionLines-1 {
+		if i < maxLines-1 {
 			fmt.Fprint(le.client.output, "\n\r")
 		}
 	}
 
 	// Restore cursor
 	fmt.Fprint(le.client.output, "\0338")
-	le.completionLines = 0
 }
 
 // hideCompletionsIfVisible clears and hides the completion list if shown

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -400,7 +400,7 @@ func (le *LineEditor) refreshDisplay() {
 
 	// Anchor to top-of-input (restore if exists, else move up by currentLineIndex)
 	if le.anchorSaved {
-		fmt.Fprint(le.client.output, "\033[u")
+		fmt.Fprint(le.client.output, "\x1b8")
 	} else {
 		if currentLineIndex > 0 {
 			fmt.Fprintf(le.client.output, "\033[%dA", currentLineIndex)
@@ -471,7 +471,7 @@ func (le *LineEditor) refreshDisplay() {
 	if currentLineIndex > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dA", currentLineIndex)
 	}
-	fmt.Fprint(le.client.output, "\r\033[s")
+	fmt.Fprint(le.client.output, "\r\x1b7")
 	if currentLineIndex > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", currentLineIndex)
 	}
@@ -495,8 +495,8 @@ func (le *LineEditor) clearCompletionArea(maxLines int) {
 	if maxLines <= 0 {
 		maxLines = 1
 	}
-	// Save cursor (CSI s)
-	fmt.Fprint(le.client.output, "\033[s")
+	// Save cursor (DECSC)
+	fmt.Fprint(le.client.output, "\x1b7")
 
 	// Move to the bottom of the input block
 	lines := strings.Split(le.line, "\n")
@@ -510,8 +510,8 @@ func (le *LineEditor) clearCompletionArea(maxLines int) {
 	// Move to first completion line and clear to end of screen
 	fmt.Fprint(le.client.output, "\033[1B\r\033[J")
 
-	// Restore cursor (CSI u)
-	fmt.Fprint(le.client.output, "\033[u")
+	// Restore cursor (DECRC)
+	fmt.Fprint(le.client.output, "\x1b8")
 }
 
 // hideCompletionsIfVisible clears and hides the completion list if shown

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -419,8 +419,8 @@ func (le *LineEditor) showOrUpdateCompletions() {
 	// Clear exactly the previously drawn completion block to avoid duplication/scroll
 	le.clearCompletions()
 
-	// Save cursor position
-	fmt.Fprint(le.client.output, "\0337")
+	// Save cursor position (CSI s for compatibility)
+	fmt.Fprint(le.client.output, "\033[s")
 
 	// Move to the bottom of the input block
 	lines := strings.Split(le.line, "\n")
@@ -434,6 +434,9 @@ func (le *LineEditor) showOrUpdateCompletions() {
 	// Move exactly one line below the input start and return to column 0
 	fmt.Fprint(le.client.output, "\033[1B\r")
 
+	// Clear from cursor to end of screen to remove any prior completion remnants
+	fmt.Fprint(le.client.output, "\033[J")
+
 	// Render completions without trailing blank line
 	raw := le.completionSelector.RenderCompletions(8)
 	block := strings.TrimRight(raw, "\n")
@@ -445,8 +448,8 @@ func (le *LineEditor) showOrUpdateCompletions() {
 		le.completionLines = 0
 	}
 
-	// Restore cursor position
-	fmt.Fprint(le.client.output, "\0338")
+	// Restore cursor position (CSI u)
+	fmt.Fprint(le.client.output, "\033[u")
 }
 
 // clearCompletions clears the completion block below the input
@@ -464,8 +467,8 @@ func (le *LineEditor) clearCompletionArea(maxLines int) {
 	if maxLines <= 0 {
 		maxLines = 1
 	}
-	// Save cursor
-	fmt.Fprint(le.client.output, "\0337")
+	// Save cursor (CSI s)
+	fmt.Fprint(le.client.output, "\033[s")
 
 	// Move to the bottom of the input block
 	lines := strings.Split(le.line, "\n")
@@ -476,19 +479,11 @@ func (le *LineEditor) clearCompletionArea(maxLines int) {
 	if down > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", down)
 	}
-	// Move to first completion line
-	fmt.Fprint(le.client.output, "\033[1B\r")
+	// Move to first completion line and clear to end of screen
+	fmt.Fprint(le.client.output, "\033[1B\r\033[J")
 
-	// Clear requested number of lines without introducing newlines
-	for i := 0; i < maxLines; i++ {
-		fmt.Fprint(le.client.output, "\r\033[K")
-		if i < maxLines-1 {
-			fmt.Fprint(le.client.output, "\033[1B")
-		}
-	}
-
-	// Restore cursor
-	fmt.Fprint(le.client.output, "\0338")
+	// Restore cursor (CSI u)
+	fmt.Fprint(le.client.output, "\033[u")
 }
 
 // hideCompletionsIfVisible clears and hides the completion list if shown

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -371,8 +371,8 @@ func (le *LineEditor) refreshDisplay() {
 	currentLineIndex := len(linesBeforeCursor) - 1
 	currentColumn := len(linesBeforeCursor[len(linesBeforeCursor)-1])
 
-	// Move to the top of the previously drawn input block and clear it
-	n := le.displayedLines
+	// Move to the top of the previously drawn block (input + completions) and clear it
+	n := le.displayedLines + le.completionLines
 	if n > 0 {
 		if n > 1 {
 			fmt.Fprintf(le.client.output, "\033[%dA", n-1)
@@ -399,6 +399,41 @@ func (le *LineEditor) refreshDisplay() {
 		fmt.Fprint(le.client.output, lines[i])
 	}
 
+	// Draw completions below input when visible
+	printedCompletionLines := 0
+	if le.completionsVisible && le.completionSelector != nil && le.completionSelector.IsVisible() {
+		items := le.completionSelector.items
+		maxItems := 8
+		start := 0
+		end := len(items)
+		if maxItems > 0 && end > maxItems {
+			start = le.completionSelector.selectedIndex - maxItems/2
+			if start < 0 {
+				start = 0
+			}
+			end = start + maxItems
+			if end > len(items) {
+				end = len(items)
+				start = end - maxItems
+				if start < 0 {
+					start = 0
+				}
+			}
+		}
+		// Header
+		fmt.Fprint(le.client.output, "\n\rCompletions:\n")
+		printedCompletionLines++ // header
+		// Items
+		for i := start; i < end; i++ {
+			marker := "  "
+			if i == le.completionSelector.selectedIndex {
+				marker = "▶ "
+			}
+			fmt.Fprintf(le.client.output, "\r%s%s\n", marker, items[i].Text)
+			printedCompletionLines++
+		}
+	}
+
 	// Position cursor
 	if len(lines) > 1 {
 		fmt.Fprintf(le.client.output, "\033[%dA", len(lines)-1)
@@ -412,6 +447,7 @@ func (le *LineEditor) refreshDisplay() {
 	}
 
 	le.displayedLines = len(lines)
+	le.completionLines = printedCompletionLines
 }
 
 // showOrUpdateCompletions renders the current completion list below the input while preserving cursor

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -433,13 +433,19 @@ func (le *LineEditor) showOrUpdateCompletions() {
 	if down > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", down)
 	}
+	// Move exactly one line below the input start and return to column 0
+	fmt.Fprint(le.client.output, "\033[1B\r")
 
-	// Move to next line and render completions
-	fmt.Fprint(le.client.output, "\n\r")
-	block := le.completionSelector.RenderCompletions(8)
-	fmt.Fprint(le.client.output, "\r")
-	fmt.Fprint(le.client.output, block)
-	le.completionLines = strings.Count(block, "\n")
+	// Render completions without trailing blank line
+	raw := le.completionSelector.RenderCompletions(8)
+	block := strings.TrimRight(raw, "\n")
+	if block != "" {
+		fmt.Fprint(le.client.output, block)
+		// Count visual lines (lines = number of '\n' + 1)
+		le.completionLines = strings.Count(block, "\n") + 1
+	} else {
+		le.completionLines = 0
+	}
 
 	// Restore cursor position
 	fmt.Fprint(le.client.output, "\0338")
@@ -453,7 +459,7 @@ func (le *LineEditor) clearCompletions() {
 	// Save cursor
 	fmt.Fprint(le.client.output, "\0337")
 
-	// Move to the bottom of the input block
+	// Move to the bottom of the input block and down to the first completion line
 	lines := strings.Split(le.line, "\n")
 	textBeforeCursor := le.line[:le.cursor]
 	linesBeforeCursor := strings.Split(textBeforeCursor, "\n")
@@ -462,12 +468,13 @@ func (le *LineEditor) clearCompletions() {
 	if down > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", down)
 	}
-	// Move to the first line of completions (line after input)
-	fmt.Fprint(le.client.output, "\n\r")
+	fmt.Fprint(le.client.output, "\033[1B\r")
+
+	// Clear exactly the number of lines previously drawn
 	for i := 0; i < le.completionLines; i++ {
-		fmt.Fprint(le.client.output, "\r\033[K")
+		fmt.Fprint(le.client.output, "\033[K")
 		if i < le.completionLines-1 {
-			fmt.Fprint(le.client.output, "\n")
+			fmt.Fprint(le.client.output, "\n\r")
 		}
 	}
 

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -385,11 +385,10 @@ func (le *LineEditor) refreshDisplay() {
 		fmt.Fprint(le.client.output, lines[i])
 	}
 
-	// Draw completions below input when visible
-	printedCompletionLines := 0
+	// Draw completions inline (no extra lines) to avoid prompt duplication/scroll
 	if le.completionsVisible && le.completionSelector != nil && le.completionSelector.IsVisible() {
 		items := le.completionSelector.items
-		maxItems := 8
+		maxItems := 6
 		start := 0
 		end := len(items)
 		if maxItems > 0 && end > maxItems {
@@ -406,25 +405,31 @@ func (le *LineEditor) refreshDisplay() {
 				}
 			}
 		}
-		// Header
-		fmt.Fprint(le.client.output, "\n\rCompletions:\n")
-		printedCompletionLines++ // header
-		// Items
-		for i := start; i < end; i++ {
-			marker := "  "
-			if i == le.completionSelector.selectedIndex {
-				marker = "▶ "
-			}
-			fmt.Fprintf(le.client.output, "\r%s%s\n", marker, items[i].Text)
-			printedCompletionLines++
+		// Save cursor, move to end of first line, print suggestions, restore cursor
+		fmt.Fprint(le.client.output, "\033[s")
+		right := visibleLength(le.prompt) + len(lines[0]) + 1
+		if right < 1 {
+			right = 1
 		}
+		fmt.Fprint(le.client.output, "\r")
+		fmt.Fprintf(le.client.output, "\033[%dC", right)
+		// Build inline suggestions
+		inline := " Completions: "
+		for i := start; i < end; i++ {
+			if i > start {
+				inline += "  "
+			}
+			if i == le.completionSelector.selectedIndex {
+				inline += "▶ "
+			}
+			inline += items[i].Text
+		}
+		fmt.Fprint(le.client.output, inline)
+		fmt.Fprint(le.client.output, "\033[K") // clear residue to EOL
+		fmt.Fprint(le.client.output, "\033[u")
 	}
 
-	// Reposition cursor to current input line/column
-	moveUp := printedCompletionLines + (len(lines) - 1 - currentLineIndex)
-	if moveUp > 0 {
-		fmt.Fprintf(le.client.output, "\033[%dA", moveUp)
-	}
+	// Reposition cursor to current input line/column (inline menu uses no extra lines)
 	fmt.Fprint(le.client.output, "\r")
 	if currentLineIndex > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", currentLineIndex)
@@ -434,7 +439,7 @@ func (le *LineEditor) refreshDisplay() {
 	}
 
 	le.displayedLines = len(lines)
-	le.completionLines = printedCompletionLines
+	le.completionLines = 0
 }
 
 // (no-op) legacy completion updater removed; integrated rendering handles it

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -23,6 +23,12 @@ type LineEditor struct {
 	cursorOnExitLine bool        // Track if cursor is positioned on the line above exit message
 	ctrlCTimer       *time.Timer // Timer to reset Ctrl+C state after 1 second
 	displayedLines   int         // Track how many lines we've displayed
+
+	// Completion UI state
+	completionSelector   *CompletionSelector
+	completionsVisible   bool
+	completionLines      int
+	completionTokenStart int
 }
 
 // NewLineEditor creates a new line editor
@@ -33,14 +39,17 @@ func NewLineEditor(client *Client) (*LineEditor, error) {
 	}
 
 	return &LineEditor{
-		client:         client,
-		keyboard:       keyboard,
-		history:        []string{},
-		historyIndex:   -1,
-		line:           "",
-		cursor:         0,
-		prompt:         client.prompt,
-		displayedLines: 0,
+		client:             client,
+		keyboard:           keyboard,
+		history:            []string{},
+		historyIndex:       -1,
+		line:               "",
+		cursor:             0,
+		prompt:             client.prompt,
+		displayedLines:     0,
+		completionSelector: NewCompletionSelector(),
+		completionsVisible: false,
+		completionLines:    0,
 	}, nil
 }
 
@@ -76,6 +85,12 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 
 		switch key.Type {
 		case KeyEnter:
+			// If completion menu is visible, accept the selection
+			if le.completionsVisible {
+				if le.applySelectedCompletion() {
+					continue
+				}
+			}
 			// Finish input
 			fmt.Fprint(le.client.output, "\n")
 			result := le.line
@@ -136,6 +151,7 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 		case KeyBackspace:
 			// Update buffer then refresh display so character disappears visually
 			if le.cursor > 0 {
+				le.hideCompletionsIfVisible()
 				le.handleBackspace()
 				le.refreshDisplay()
 			}
@@ -143,6 +159,7 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 		case KeyDelete:
 			// Update buffer then refresh display to reflect deletion
 			if le.cursor < len(le.line) {
+				le.hideCompletionsIfVisible()
 				le.handleDelete()
 				le.refreshDisplay()
 			}
@@ -150,6 +167,7 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 		case KeyArrowLeft:
 			// Move cursor and refresh to reposition visibly (supports multiline)
 			if le.cursor > 0 {
+				le.hideCompletionsIfVisible()
 				le.moveCursorLeft()
 				le.refreshDisplay()
 			}
@@ -157,21 +175,40 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 		case KeyArrowRight:
 			// Move cursor and refresh to reposition visibly (supports multiline)
 			if le.cursor < len(le.line) {
+				le.hideCompletionsIfVisible()
 				le.moveCursorRight()
 				le.refreshDisplay()
 			}
 
 		case KeyArrowUp:
+			if le.completionsVisible {
+				if le.completionSelector.MoveUp() {
+					le.showOrUpdateCompletions()
+				}
+				continue
+			}
 			// Navigate history and refresh to show selected entry
 			le.navigateHistory(-1)
 			le.refreshDisplay()
 
 		case KeyArrowDown:
+			if le.completionsVisible {
+				if le.completionSelector.MoveDown() {
+					le.showOrUpdateCompletions()
+				}
+				continue
+			}
 			// Navigate history and refresh to show selected entry
 			le.navigateHistory(1)
 			le.refreshDisplay()
 
 		case KeyTab:
+			// If completions are visible, accept the current selection
+			if le.completionsVisible {
+				if le.applySelectedCompletion() {
+					continue
+				}
+			}
 			// Implement tab completion using client's completionFunc
 			// Determine the current token (from last whitespace/newline to cursor)
 			start := le.cursor
@@ -214,29 +251,26 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 				continue
 			}
 
-			// No further extension; show the list of completions below aligned to column 0
-			fmt.Fprint(le.client.output, "\n\r")
-			fmt.Fprint(le.client.output, "Completions:\n")
-			for i, c := range candidates {
-				marker := "  "
-				if i == 0 {
-					marker = "▶ "
-				}
-				fmt.Fprintf(le.client.output, "\r%s%s\n", marker, c)
+			// No further extension; show interactive list below input
+			le.completionTokenStart = start
+			items := make([]CompletionItem, 0, len(candidates))
+			for _, c := range candidates {
+				items = append(items, CompletionItem{Text: c})
 			}
-			fmt.Fprint(le.client.output, "\r\n")
-			// Render a fresh prompt+input below the list without trying to clear above
-			le.displayedLines = 0
-			le.refreshDisplay()
+			le.completionSelector.SetItems(items)
+			le.completionsVisible = true
+			le.showOrUpdateCompletions()
 			continue
 
 		case KeyCtrlJ:
 			// Insert newline for multiline input
+			le.hideCompletionsIfVisible()
 			le.insertRune('\n')
 			le.refreshDisplay()
 			continue
 
 		case KeyRune:
+			le.hideCompletionsIfVisible()
 			le.insertRune(key.Rune)
 
 			// Use smart refresh: simple echo for single-line, no refresh for multiline character input
@@ -378,6 +412,94 @@ func (le *LineEditor) refreshDisplay() {
 	}
 
 	le.displayedLines = len(lines)
+}
+
+// showOrUpdateCompletions renders the current completion list below the input while preserving cursor
+func (le *LineEditor) showOrUpdateCompletions() {
+	// Clear previous list if present
+	if le.completionLines > 0 {
+		le.clearCompletions()
+	}
+
+	// Save cursor position
+	fmt.Fprint(le.client.output, "\0337")
+
+	// Move to the bottom of the input block
+	lines := strings.Split(le.line, "\n")
+	textBeforeCursor := le.line[:le.cursor]
+	linesBeforeCursor := strings.Split(textBeforeCursor, "\n")
+	currentLineIndex := len(linesBeforeCursor) - 1
+	down := len(lines) - 1 - currentLineIndex
+	if down > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dB", down)
+	}
+
+	// Move to next line and render completions
+	fmt.Fprint(le.client.output, "\n\r")
+	block := le.completionSelector.RenderCompletions(8)
+	fmt.Fprint(le.client.output, "\r")
+	fmt.Fprint(le.client.output, block)
+	le.completionLines = strings.Count(block, "\n")
+
+	// Restore cursor position
+	fmt.Fprint(le.client.output, "\0338")
+}
+
+// clearCompletions clears the completion block below the input
+func (le *LineEditor) clearCompletions() {
+	if le.completionLines <= 0 {
+		return
+	}
+	// Save cursor
+	fmt.Fprint(le.client.output, "\0337")
+
+	// Move to the bottom of the input block
+	lines := strings.Split(le.line, "\n")
+	textBeforeCursor := le.line[:le.cursor]
+	linesBeforeCursor := strings.Split(textBeforeCursor, "\n")
+	currentLineIndex := len(linesBeforeCursor) - 1
+	down := len(lines) - 1 - currentLineIndex
+	if down > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dB", down)
+	}
+	// Move to the first line of completions (line after input)
+	fmt.Fprint(le.client.output, "\n\r")
+	for i := 0; i < le.completionLines; i++ {
+		fmt.Fprint(le.client.output, "\r\033[K")
+		if i < le.completionLines-1 {
+			fmt.Fprint(le.client.output, "\n")
+		}
+	}
+
+	// Restore cursor
+	fmt.Fprint(le.client.output, "\0338")
+	le.completionLines = 0
+}
+
+// hideCompletionsIfVisible clears and hides the completion list if shown
+func (le *LineEditor) hideCompletionsIfVisible() {
+	if le.completionsVisible {
+		le.clearCompletions()
+		le.completionsVisible = false
+		le.completionSelector.Clear()
+	}
+}
+
+// applySelectedCompletion inserts the selected completion text
+func (le *LineEditor) applySelectedCompletion() bool {
+	if !le.completionsVisible {
+		return false
+	}
+	sel := le.completionSelector.GetSelectedItem()
+	if sel == nil {
+		return false
+	}
+	start := le.completionTokenStart
+	le.line = le.line[:start] + sel.Text + le.line[le.cursor:]
+	le.cursor = start + len(sel.Text)
+	le.hideCompletionsIfVisible()
+	le.refreshDisplay()
+	return true
 }
 
 // refreshDisplayWithoutPrompt redraws the current line(s) without showing the prompt

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -416,8 +416,8 @@ func (le *LineEditor) refreshDisplay() {
 
 // showOrUpdateCompletions renders the current completion list below the input while preserving cursor
 func (le *LineEditor) showOrUpdateCompletions() {
-	// Aggressively clear any prior completion area to avoid duplicates/blank lines
-	le.clearCompletionArea(24)
+	// Clear exactly the previously drawn completion block to avoid duplication/scroll
+	le.clearCompletions()
 
 	// Save cursor position
 	fmt.Fprint(le.client.output, "\0337")

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -28,6 +28,7 @@ type LineEditor struct {
 	completionSelector   *CompletionSelector
 	completionsVisible   bool
 	completionLines      int
+	anchorSaved          bool
 	completionTokenStart int
 }
 
@@ -73,6 +74,8 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 	le.cursor = 0
 	le.historyIndex = -1
 	le.displayedLines = 0
+	le.anchorSaved = false
+	le.anchorSaved = false
 
 	// Show initial prompt
 	le.refreshDisplay()
@@ -371,26 +374,13 @@ func (le *LineEditor) refreshDisplay() {
 	currentLineIndex := len(linesBeforeCursor) - 1
 	currentColumn := len(linesBeforeCursor[len(linesBeforeCursor)-1])
 
-	// Move to the first input line from current cursor, then clear to end-of-screen
-	if currentLineIndex > 0 {
-		fmt.Fprintf(le.client.output, "\033[%dA", currentLineIndex)
-	}
-	fmt.Fprint(le.client.output, "\r\033[J")
-
-	// Draw fresh content (no leading newline; spacer is provided by welcome)
-	fmt.Fprint(le.client.output, le.prompt)
-	fmt.Fprint(le.client.output, lines[0])
-	for i := 1; i < len(lines); i++ {
-		fmt.Fprint(le.client.output, "\n\r  ")
-		fmt.Fprint(le.client.output, lines[i])
-	}
-
-	// Draw completions inline (no extra lines) to avoid prompt duplication/scroll
+	// Compute completion lines for this cycle (vertical list)
+	newCompletionLines := 0
+	start, end := 0, 0
 	if le.completionsVisible && le.completionSelector != nil && le.completionSelector.IsVisible() {
 		items := le.completionSelector.items
-		maxItems := 6
-		start := 0
-		end := len(items)
+		maxItems := 8
+		end = len(items)
 		if maxItems > 0 && end > maxItems {
 			start = le.completionSelector.selectedIndex - maxItems/2
 			if start < 0 {
@@ -405,31 +395,66 @@ func (le *LineEditor) refreshDisplay() {
 				}
 			}
 		}
-		// Save cursor, move to end of first line, print suggestions, restore cursor
-		fmt.Fprint(le.client.output, "\033[s")
-		right := visibleLength(le.prompt) + len(lines[0]) + 1
-		if right < 1 {
-			right = 1
-		}
-		fmt.Fprint(le.client.output, "\r")
-		fmt.Fprintf(le.client.output, "\033[%dC", right)
-		// Build inline suggestions
-		inline := " Completions: "
-		for i := start; i < end; i++ {
-			if i > start {
-				inline += "  "
-			}
-			if i == le.completionSelector.selectedIndex {
-				inline += "▶ "
-			}
-			inline += items[i].Text
-		}
-		fmt.Fprint(le.client.output, inline)
-		fmt.Fprint(le.client.output, "\033[K") // clear residue to EOL
-		fmt.Fprint(le.client.output, "\033[u")
+		newCompletionLines = 1 + (end - start) // header + items
 	}
 
-	// Reposition cursor to current input line/column (inline menu uses no extra lines)
+	// Anchor to top-of-input (restore if exists, else move up by currentLineIndex)
+	if le.anchorSaved {
+		fmt.Fprint(le.client.output, "\033[u")
+	} else {
+		if currentLineIndex > 0 {
+			fmt.Fprintf(le.client.output, "\033[%dA", currentLineIndex)
+		}
+		fmt.Fprint(le.client.output, "\r")
+	}
+
+	// Clear exactly the area previously used (input + completions), or new total if larger
+	prevTotal := le.displayedLines + le.completionLines
+	newTotal := len(lines) + newCompletionLines
+	clearLines := prevTotal
+	if newTotal > clearLines {
+		clearLines = newTotal
+	}
+	if clearLines > 0 {
+		for i := 0; i < clearLines; i++ {
+			fmt.Fprint(le.client.output, "\033[K")
+			if i < clearLines-1 {
+				fmt.Fprint(le.client.output, "\033[1B\r")
+			}
+		}
+		if clearLines > 1 {
+			fmt.Fprintf(le.client.output, "\033[%dA\r", clearLines-1)
+		} else {
+			fmt.Fprint(le.client.output, "\r")
+		}
+	}
+
+	// Draw input
+	fmt.Fprint(le.client.output, le.prompt)
+	fmt.Fprint(le.client.output, lines[0])
+	for i := 1; i < len(lines); i++ {
+		fmt.Fprint(le.client.output, "\n\r  ")
+		fmt.Fprint(le.client.output, lines[i])
+	}
+
+	// Draw completions vertically below input when visible
+	if newCompletionLines > 0 {
+		items := le.completionSelector.items
+		fmt.Fprint(le.client.output, "\n\rCompletions:\n")
+		for i := start; i < end; i++ {
+			marker := "  "
+			if i == le.completionSelector.selectedIndex {
+				marker = "▶ "
+			}
+			fmt.Fprintf(le.client.output, "\r%s%s\n", marker, items[i].Text)
+		}
+	}
+
+	// Move cursor back to the input cursor position
+	moveUp := newCompletionLines + (len(lines) - 1 - currentLineIndex)
+	if moveUp > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dA", moveUp)
+	}
 	fmt.Fprint(le.client.output, "\r")
 	if currentLineIndex > 0 {
 		fmt.Fprintf(le.client.output, "\033[%dB", currentLineIndex)
@@ -438,8 +463,19 @@ func (le *LineEditor) refreshDisplay() {
 		fmt.Fprintf(le.client.output, "\033[%dC", visibleLength(le.prompt)+currentColumn)
 	}
 
+	// Update counters
 	le.displayedLines = len(lines)
-	le.completionLines = 0
+	le.completionLines = newCompletionLines
+
+	// Save anchor at top-of-input for next refresh
+	if currentLineIndex > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dA", currentLineIndex)
+	}
+	fmt.Fprint(le.client.output, "\r\033[s")
+	if currentLineIndex > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dB", currentLineIndex)
+	}
+	le.anchorSaved = true
 }
 
 // (no-op) legacy completion updater removed; integrated rendering handles it

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -183,7 +183,7 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 		case KeyArrowUp:
 			if le.completionsVisible {
 				if le.completionSelector.MoveUp() {
-					le.showOrUpdateCompletions()
+					le.refreshDisplay()
 				}
 				continue
 			}
@@ -194,7 +194,7 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 		case KeyArrowDown:
 			if le.completionsVisible {
 				if le.completionSelector.MoveDown() {
-					le.showOrUpdateCompletions()
+					le.refreshDisplay()
 				}
 				continue
 			}
@@ -259,7 +259,7 @@ func (le *LineEditor) ReadLineWithHistory() (string, error) {
 			}
 			le.completionSelector.SetItems(items)
 			le.completionsVisible = true
-			le.showOrUpdateCompletions()
+			le.refreshDisplay()
 			continue
 
 		case KeyCtrlJ:
@@ -437,43 +437,7 @@ func (le *LineEditor) refreshDisplay() {
 	le.completionLines = printedCompletionLines
 }
 
-// showOrUpdateCompletions renders the current completion list below the input while preserving cursor
-func (le *LineEditor) showOrUpdateCompletions() {
-	// Clear exactly the previously drawn completion block to avoid duplication/scroll
-	le.clearCompletions()
-
-	// Save cursor position (CSI s for compatibility)
-	fmt.Fprint(le.client.output, "\033[s")
-
-	// Move to the bottom of the input block
-	lines := strings.Split(le.line, "\n")
-	textBeforeCursor := le.line[:le.cursor]
-	linesBeforeCursor := strings.Split(textBeforeCursor, "\n")
-	currentLineIndex := len(linesBeforeCursor) - 1
-	down := len(lines) - 1 - currentLineIndex
-	if down > 0 {
-		fmt.Fprintf(le.client.output, "\033[%dB", down)
-	}
-	// Move exactly one line below the input start and return to column 0
-	fmt.Fprint(le.client.output, "\033[1B\r")
-
-	// Clear from cursor to end of screen to remove any prior completion remnants
-	fmt.Fprint(le.client.output, "\033[J")
-
-	// Render completions without trailing blank line
-	raw := le.completionSelector.RenderCompletions(8)
-	block := strings.TrimRight(raw, "\n")
-	if block != "" {
-		fmt.Fprint(le.client.output, block)
-		// Count visual lines (lines = number of '\n' + 1)
-		le.completionLines = strings.Count(block, "\n") + 1
-	} else {
-		le.completionLines = 0
-	}
-
-	// Restore cursor position (CSI u)
-	fmt.Fprint(le.client.output, "\033[u")
-}
+// (no-op) legacy completion updater removed; integrated rendering handles it
 
 // clearCompletions clears the completion block below the input
 func (le *LineEditor) clearCompletions() {

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -429,24 +429,27 @@ func (le *LineEditor) refreshDisplay() {
 		}
 	}
 
-	// Draw input
+	// Draw input (no newlines)
 	fmt.Fprint(le.client.output, le.prompt)
 	fmt.Fprint(le.client.output, lines[0])
 	for i := 1; i < len(lines); i++ {
-		fmt.Fprint(le.client.output, "\n\r  ")
+		fmt.Fprint(le.client.output, "\033[1B\r\033[K  ")
 		fmt.Fprint(le.client.output, lines[i])
 	}
 
-	// Draw completions vertically below input when visible
+	// Draw completions vertically below input when visible (no newlines)
 	if newCompletionLines > 0 {
 		items := le.completionSelector.items
-		fmt.Fprint(le.client.output, "\n\rCompletions:\n")
+		// Header
+		fmt.Fprint(le.client.output, "\033[1B\r\033[KCompletions:")
+		// Items
 		for i := start; i < end; i++ {
 			marker := "  "
 			if i == le.completionSelector.selectedIndex {
 				marker = "▶ "
 			}
-			fmt.Fprintf(le.client.output, "\r%s%s\n", marker, items[i].Text)
+			fmt.Fprint(le.client.output, "\033[1B\r\033[K")
+			fmt.Fprintf(le.client.output, "%s%s", marker, items[i].Text)
 		}
 	}
 

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -371,25 +371,11 @@ func (le *LineEditor) refreshDisplay() {
 	currentLineIndex := len(linesBeforeCursor) - 1
 	currentColumn := len(linesBeforeCursor[len(linesBeforeCursor)-1])
 
-	// Move to the top of the previously drawn block (input + completions) and clear it
-	n := le.displayedLines + le.completionLines
-	if n > 0 {
-		if n > 1 {
-			fmt.Fprintf(le.client.output, "\033[%dA", n-1)
-		}
-		fmt.Fprint(le.client.output, "\r")
-		for i := 0; i < n; i++ {
-			fmt.Fprint(le.client.output, "\033[K")
-			if i < n-1 {
-				fmt.Fprint(le.client.output, "\033[1B\r")
-			}
-		}
-		if n > 1 {
-			fmt.Fprintf(le.client.output, "\033[%dA\r", n-1)
-		} else {
-			fmt.Fprint(le.client.output, "\r")
-		}
+	// Move to the first input line from current cursor, then clear to end-of-screen
+	if currentLineIndex > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dA", currentLineIndex)
 	}
+	fmt.Fprint(le.client.output, "\r\033[J")
 
 	// Draw fresh content (no leading newline; spacer is provided by welcome)
 	fmt.Fprint(le.client.output, le.prompt)
@@ -434,9 +420,10 @@ func (le *LineEditor) refreshDisplay() {
 		}
 	}
 
-	// Position cursor
-	if len(lines) > 1 {
-		fmt.Fprintf(le.client.output, "\033[%dA", len(lines)-1)
+	// Reposition cursor to current input line/column
+	moveUp := printedCompletionLines + (len(lines) - 1 - currentLineIndex)
+	if moveUp > 0 {
+		fmt.Fprintf(le.client.output, "\033[%dA", moveUp)
 	}
 	fmt.Fprint(le.client.output, "\r")
 	if currentLineIndex > 0 {

--- a/lib/termflow/readline.go
+++ b/lib/termflow/readline.go
@@ -479,11 +479,11 @@ func (le *LineEditor) clearCompletionArea(maxLines int) {
 	// Move to first completion line
 	fmt.Fprint(le.client.output, "\033[1B\r")
 
-	// Clear requested number of lines
+	// Clear requested number of lines without introducing newlines
 	for i := 0; i < maxLines; i++ {
-		fmt.Fprint(le.client.output, "\033[K")
+		fmt.Fprint(le.client.output, "\r\033[K")
 		if i < maxLines-1 {
-			fmt.Fprint(le.client.output, "\n\r")
+			fmt.Fprint(le.client.output, "\033[1B")
 		}
 	}
 

--- a/lib/termflow/uitest/completion_duplicate_test.go
+++ b/lib/termflow/uitest/completion_duplicate_test.go
@@ -1,0 +1,118 @@
+package uitest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// countInTail counts occurrences of the needle within the last N visible lines
+func countInTail(tt *TerminalTest, needle string, tailLines int) int {
+	lines := tt.GetLines()
+	if tailLines > len(lines) {
+		tailLines = len(lines)
+	}
+	tail := lines[len(lines)-tailLines:]
+	count := 0
+	for _, ln := range tail {
+		if strings.Contains(ln, needle) {
+			count++
+		}
+	}
+	return count
+}
+
+// TestCompletion_NoDuplicateBlocks_OnNavigation ensures the completion header doesn't duplicate
+func TestCompletion_NoDuplicateBlocks_OnNavigation(t *testing.T) {
+	if os.Getenv("RIGEL_TEST_MODE") != "1" {
+		t.Skip("set RIGEL_TEST_MODE=1 to run PTY completion duplication test")
+	}
+
+	rigelPath, _ := filepath.Abs(filepath.FromSlash("../../bin/rigel"))
+	if _, err := os.Stat(rigelPath); err != nil {
+		t.Skipf("rigel binary not found at %s; build first", rigelPath)
+	}
+
+	tt, err := NewTerminalTest(t, rigelPath)
+	if err != nil {
+		t.Fatalf("failed to start terminal session: %v", err)
+	}
+	defer tt.Close()
+
+	tt.Wait(400 * time.Millisecond)
+	if !tt.ExpectWelcome() {
+		t.Fatalf("welcome not visible")
+	}
+
+	// Trigger completion menu
+	if err := tt.SendKeys("/"); err != nil {
+		t.Fatalf("send '/' failed: %v", err)
+	}
+	tt.Wait(120 * time.Millisecond)
+	if err := tt.SendKeys("\t"); err != nil { // Tab
+		t.Fatalf("send Tab failed: %v", err)
+	}
+	tt.Wait(200 * time.Millisecond)
+
+	// Navigate a bit: Down, Down, Up, Down
+	seq := []string{"\x1b[B", "\x1b[B", "\x1b[A", "\x1b[B"}
+	for _, s := range seq {
+		if err := tt.SendKeys(s); err != nil {
+			t.Fatalf("send arrow failed: %v", err)
+		}
+		tt.Wait(120 * time.Millisecond)
+	}
+
+	// In the last 60 lines, we should have exactly one Completions: header
+	headers := countInTail(tt, "Completions:", 60)
+	if headers != 1 {
+		t.Fatalf("expected exactly 1 completion header in tail, got %d\n%s", headers, tt.Screenshot())
+	}
+}
+
+// TestCompletion_MenuClosesOnApply ensures the menu is cleared after apply
+func TestCompletion_MenuClosesOnApply(t *testing.T) {
+	if os.Getenv("RIGEL_TEST_MODE") != "1" {
+		t.Skip("set RIGEL_TEST_MODE=1 to run PTY completion apply test")
+	}
+
+	rigelPath, _ := filepath.Abs(filepath.FromSlash("../../bin/rigel"))
+	if _, err := os.Stat(rigelPath); err != nil {
+		t.Skipf("rigel binary not found at %s; build first", rigelPath)
+	}
+
+	tt, err := NewTerminalTest(t, rigelPath)
+	if err != nil {
+		t.Fatalf("failed to start terminal session: %v", err)
+	}
+	defer tt.Close()
+
+	tt.Wait(400 * time.Millisecond)
+	if !tt.ExpectWelcome() {
+		t.Fatalf("welcome not visible")
+	}
+
+	// Show menu
+	if err := tt.SendKeys("/"); err != nil {
+		t.Fatalf("send '/' failed: %v", err)
+	}
+	tt.Wait(120 * time.Millisecond)
+	if err := tt.SendKeys("\t"); err != nil {
+		t.Fatalf("send Tab failed: %v", err)
+	}
+	tt.Wait(200 * time.Millisecond)
+
+	// Apply with Tab
+	if err := tt.SendKeys("\t"); err != nil {
+		t.Fatalf("send Tab apply failed: %v", err)
+	}
+	tt.Wait(200 * time.Millisecond)
+
+	// After apply, in the last 40 lines there should be 0 headers
+	headers := countInTail(tt, "Completions:", 40)
+	if headers != 0 {
+		t.Fatalf("expected 0 completion headers after apply, got %d\n%s", headers, tt.Screenshot())
+	}
+}


### PR DESCRIPTION
Make termflow completions navigable with arrow keys and selectable with Tab/Enter.

Summary
- Turn the completion list into an interactive menu rendered below the input.
- Up/Down navigates, Tab or Enter accepts, typing cancels the list.

Changes
- lib/termflow/readline.go:
  - Add completion state and `CompletionSelector` to `LineEditor`.
  - Render/clear the completion block below the input without shifting the prompt.
  - Intercept ArrowUp/ArrowDown when completions are visible to move selection.
  - Apply selected completion on Tab/Enter; hide on edit/movement.

Motivation & Context
- Previously the list showed a ▶ marker but could not be navigated, leading to confusion.

How Tested
- Manual: `/h` + Tab → shows list; Up/Down moves ▶; Tab applies selection; further typing cancels the list.
- `go test ./... -short` passes.

Impact
- Improves UX consistency with common REPLs; no API changes.
